### PR TITLE
Make sure workspace exists before sending files

### DIFF
--- a/splunk-devops/src/main/java/com/splunk/splunkjenkins/utils/LogEventHelper.java
+++ b/splunk-devops/src/main/java/com/splunk/splunkjenkins/utils/LogEventHelper.java
@@ -260,6 +260,11 @@ public class LogEventHelper {
         final String expanded = Util.replaceMacro(includes, envVars);
         final String exclude = Util.replaceMacro(excludes, envVars);
         try {
+            if (!ws.exists()) {
+                LOG.warning("ws doesn't exist: " + ws.getRemote());
+                return eventCount;
+            }
+            
             final FilePath[] paths = ws.list(expanded, exclude);
             if (paths.length == 0) {
                 LOG.warning("can not find files using includes:" + includes + " excludes:" + excludes + " in workspace:" + ws.getRemote());


### PR DESCRIPTION
We have tons of jobs with large amount of outputs so we always delete the ws at the end of each build, which apparently causes lots of noise in the console log when we activate this plugin.