### PR TITLE
Add ExtensionPoint for Message Queue, Retry 502 Errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,12 @@
             <scope>test</scope> <!--only used to setup token and execute search-->
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.18.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>annotations</artifactId>
             <version>3.0.0</version>

--- a/readme.md
+++ b/readme.md
@@ -3,17 +3,14 @@ Splunk for Jenkins
 
 To Install Develop Version
 ----
- - clone the repo
- - `$ mvn package`
- -  That will generate `splunk-devops/target/splunk-devops.hpi` which you can install into Jenkins by the web interface or just put it in the `JENKINS_HOME/plugins` folder.
- - `$ mvn clean verify -Dhost=localhost -Dusername=admin -Dpassword=changeme`
-   to run tests against local splunk instance
-
+ - Clone the repo
+ - Run `$ mvn package` to generate `splunk-devops/target/splunk-devops.hpi`, which you can install into Jenkins via the web interface or just put it in the `$JENKINS_HOME/plugins` folder.
+ - Run `$ mvn clean verify -Dhost=localhost -Dusername=admin -Dpassword=changeme`
+   to run tests against a [local Splunk instance](https://www.splunk.com/en_us/download.html).
 
 To Setup
 ----
 ### Configure plugin
-
  - Go to https://jenkins-url/configure
  - Enter Hostname, Port, and Token
  - Enable RawEvent support if you are using Splunk version 6.3.1511 or later
@@ -57,13 +54,13 @@ splunkins.archive("**/*.log", null, false, "10MB")
 
   ![Screenshot](doc/images/splunk_for_jenkins_post_job.png)
  
+### Customize message queue
+By default, this plugin uses a [LinkedBlockingQueue](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/LinkedBlockingQueue.html) as a message queue for information transferred between Jenkins and Splunk. However, this can be updated if a plugin is installed that leverages the [SplunkQueue](splunk-devops/src/main/java/com/splunk/splunkjenkins/utils/SplunkQueue.java) [ExtensionPoint](https://javadoc.jenkins.io/hudson/ExtensionPoint.html).
+
 Dashboard
 ----
-
-you can get the "Splunk App for Jenkins" App from [splunk base](https://splunkbase.splunk.com/app/3332/)
-
+You can get the "Splunk App for Jenkins" App from [Splunkbase](https://splunkbase.splunk.com/app/3332/).
 
 System Requirement
 -----
-You need enable "HTTP Event Collector" In Splunk to use the plugin,
-please checkout [HTTP Event Collector](http://dev.splunk.com/view/event-collector/SP-CAAAE7G)
+You need enable "HTTP Event Collector" in Splunk to use the plugin, please checkout [HTTP Event Collector](http://dev.splunk.com/view/event-collector/SP-CAAAE7G) and [HTTP Event Collector Walkthrough](http://docs.splunk.com/Documentation/Splunk/7.1.0/Data/HECWalkthrough).

--- a/splunk-devops/src/main/java/com/splunk/splunkjenkins/utils/DefaultSplunkQueue.java
+++ b/splunk-devops/src/main/java/com/splunk/splunkjenkins/utils/DefaultSplunkQueue.java
@@ -1,0 +1,75 @@
+package com.splunk.splunkjenkins.utils;
+
+import hudson.Extension;
+
+import com.splunk.splunkjenkins.SplunkJenkinsInstallation;
+import com.splunk.splunkjenkins.model.EventRecord;
+import com.splunk.splunkjenkins.model.EventType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.logging.Level;
+
+@Extension
+public class DefaultSplunkQueue extends LinkedBlockingQueue<EventRecord> implements SplunkQueue {
+    public static final java.util.logging.Logger LOG = java.util.logging.Logger.getLogger(DefaultSplunkQueue.class.getName());
+
+    private Lock maintenanceLock = new ReentrantLock(true); // favor access to longest-waiting thread
+    private final static int QUEUE_SIZE = 1 << 17;
+
+    public DefaultSplunkQueue(){
+        this(QUEUE_SIZE);
+    }
+
+    public DefaultSplunkQueue(int capacity) {
+        super(capacity);
+    }
+
+    @Override
+    public boolean enqueue(EventRecord record) {
+        if (SplunkJenkinsInstallation.get().isEventDisabled(record.getEventType())) {
+            LOG.log(Level.FINE, "config invalid or eventType {0} is disabled, can not send {1}", new String[]{record.getEventType().toString(), record.getShortDescription()});
+            return false;
+        }
+
+        // Insert record into queue, analyze capacity restrictions
+        boolean added = false;
+        try {
+            // Try to add, wait for space to become available
+            added = super.offer(record, 3, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            // Try to add immediately
+            added = super.offer(record);
+        }
+        if (!added) {
+            LOG.log(Level.SEVERE, "failed to send message due to queue is full");
+            if (maintenanceLock.tryLock()) {
+                try {
+                    // Event in queue may have format issues causing congestion, remove non-critical events
+                    List<EventRecord> stuckRecords = new ArrayList<>(super.size());
+                    super.drainTo(stuckRecords);
+                    LOG.log(Level.SEVERE, "jenkins is too busy or has too few workers, clearing up queue");
+                    for (EventRecord queuedRecord : stuckRecords) {
+                        if (!queuedRecord.getEventType().equals(EventType.BUILD_REPORT)) {
+                            continue;
+                        }
+                        boolean enqueued = super.offer(queuedRecord);
+                        if (!enqueued) {
+                            LOG.log(Level.SEVERE, "failed to add {0}", record.getShortDescription());
+                            break;
+                        }
+                    }
+                } finally {
+                    maintenanceLock.unlock();
+                }
+            }
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/splunk-devops/src/main/java/com/splunk/splunkjenkins/utils/LogConsumerHandler.java
+++ b/splunk-devops/src/main/java/com/splunk/splunkjenkins/utils/LogConsumerHandler.java
@@ -1,0 +1,66 @@
+package com.splunk.splunkjenkins.utils;
+
+import shaded.splk.org.apache.http.HttpEntity;
+import shaded.splk.org.apache.http.HttpResponse;
+import shaded.splk.org.apache.http.client.ResponseHandler;
+import shaded.splk.org.apache.http.util.EntityUtils;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Logger;
+
+import static com.splunk.splunkjenkins.utils.LogEventHelper.buildPost;
+
+public class LogConsumerHandler implements ResponseHandler{
+    private static final Logger LOG = Logger.getLogger(LogConsumerHandler.class.getName());
+    private AtomicLong outgoingCounter;
+    private long errorCount;
+
+    public LogConsumerHandler(long errorCount, AtomicLong counter) {
+        this.errorCount = errorCount;
+        this.outgoingCounter = counter;
+    }
+
+    @Override
+    public String handleResponse(final HttpResponse response) throws IOException {
+        int status = response.getStatusLine().getStatusCode();
+        LOG.info("LogConsumerHandler | STATUS: " + status);
+        String reason = response.getStatusLine().getReasonPhrase();
+
+        if (status == 200) {
+            outgoingCounter.incrementAndGet();
+            HttpEntity entity = response.getEntity();
+            //need consume entity so underlying connection can be released to pool
+            return entity != null ? EntityUtils.toString(entity) : null;
+        } else {
+            errorCount++;
+            //see also http://docs.splunk.com/Documentation/Splunk/6.3.0/RESTREF/RESTinput#services.2Fcollector
+
+            // SplunkServiceError
+            if (status == 503) {
+                throw new SplunkServiceError("Server is busy, maybe caused by blocked queue, please check " +
+                        "https://wiki.splunk.com/Community:TroubleshootingBlockedQueues", status);
+            }
+            if (status == 502) {
+                throw new SplunkServiceError("Bad gateway, target may have closed the connection", status);
+            }
+
+            // SplunkClientError
+            String message;
+            if (status == 403 || status == 401) {
+                //Token disabled or Invalid authorization
+                message = reason + ", http event collector token is invalid";
+            } else if (status == 400) {
+                //Invalid data format or incorrect index
+                message = reason + ", incorrect index or invalid data format";
+            } else {
+                message = reason;
+            }
+            throw new SplunkClientError(message, status);
+        }
+    }
+
+    public long getErrorCount(){
+        return errorCount;
+    }
+}

--- a/splunk-devops/src/main/java/com/splunk/splunkjenkins/utils/SplunkClientError.java
+++ b/splunk-devops/src/main/java/com/splunk/splunkjenkins/utils/SplunkClientError.java
@@ -1,0 +1,18 @@
+package com.splunk.splunkjenkins.utils;
+
+import java.io.IOException;
+import java.util.logging.Logger;
+
+public class SplunkClientError extends IOException {
+    private static final Logger LOG = Logger.getLogger(SplunkClientError.class.getName());
+    private int status;
+
+    public SplunkClientError(String message, int status) {
+        super(message + ", status code:" + status);
+        this.status = status;
+    }
+
+    public int getStatus(){
+        return status;
+    }
+}

--- a/splunk-devops/src/main/java/com/splunk/splunkjenkins/utils/SplunkQueue.java
+++ b/splunk-devops/src/main/java/com/splunk/splunkjenkins/utils/SplunkQueue.java
@@ -1,0 +1,59 @@
+package com.splunk.splunkjenkins.utils;
+
+import hudson.ExtensionPoint;
+
+import com.splunk.splunkjenkins.model.EventRecord;
+
+public interface SplunkQueue extends ExtensionPoint {
+    /**
+     * Removes all of the elements from this queue.
+     * The queue will be empty after this method returns.
+     *
+     * @throws UnsupportedOperationException if the clear operation
+     *         is not supported by this collection
+     */
+    void clear();
+
+    /**
+     * Inserts the specified element into this queue, waiting if necessary
+     * for space to become available; will also try to clear the queue,
+     * if congestion is suspected.
+     *
+     * @param record the element to add
+     * @return true if the element was added to this queue, else
+     *         false
+     * @throws NullPointerException if the specified element is null
+     * @throws IllegalArgumentException if some property of the specified
+     *         element prevents it from being added to this queue
+     */
+    boolean enqueue(EventRecord record);
+
+    /**
+     * Inserts the specified element into this queue if it is possible to do
+     * so immediately without violating capacity restrictions.
+     *
+     * @param record the element to add
+     * @return true if the element was added to this queue, else
+     *         false
+     * @throws NullPointerException if the specified element is null
+     * @throws IllegalArgumentException if some property of this element
+     *         prevents it from being added to this queue
+     */
+    boolean offer(EventRecord record);
+
+    /**
+     * Returns the number of elements in this collection.
+     *
+     * @return the number of elements in this collection
+     */
+    int size();
+
+    /**
+     * Retrieves and removes the head of this queue, waiting if necessary
+     * until an element becomes available.
+     *
+     * @return the head of this queue
+     * @throws InterruptedException if interrupted while waiting
+     */
+    EventRecord take() throws InterruptedException;
+}

--- a/splunk-devops/src/main/java/com/splunk/splunkjenkins/utils/SplunkServiceError.java
+++ b/splunk-devops/src/main/java/com/splunk/splunkjenkins/utils/SplunkServiceError.java
@@ -1,0 +1,12 @@
+package com.splunk.splunkjenkins.utils;
+
+import java.io.IOException;
+import java.util.logging.Logger;
+
+public class SplunkServiceError extends IOException {
+    private static final Logger LOG = Logger.getLogger(SplunkServiceError.class.getName());
+
+    public SplunkServiceError(String message, int status) {
+        super(message);
+    }
+}

--- a/splunk-devops/src/main/resources/com/splunk/splunkjenkins/SplunkJenkinsInstallation/config.jelly
+++ b/splunk-devops/src/main/resources/com/splunk/splunkjenkins/SplunkJenkinsInstallation/config.jelly
@@ -28,6 +28,11 @@
             <f:entry title="${%Raw Events Supported}" field="rawEventEnabled">
                 <f:checkbox default="true"/>
             </f:entry>
+            <f:entry title="${%Queue Type}" field="queueType"
+                     description="${%Type of queue for Splunk events. Changing queue type might cause events to get lost during the transition.}"
+                     help="/descriptorByName/com.splunk.splunkjenkins.SplunkJenkinsInstallation/help/queueType">
+                <f:select />
+            </f:entry>
             <f:entry title="${%Custom Metadata}">
                 <f:repeatable field="metadataItemSet">
                     <st:include page="config.jelly" class="${descriptor.clazz}"/>

--- a/splunk-devops/src/main/resources/com/splunk/splunkjenkins/SplunkJenkinsInstallation/help-queueType.html
+++ b/splunk-devops/src/main/resources/com/splunk/splunkjenkins/SplunkJenkinsInstallation/help-queueType.html
@@ -1,0 +1,5 @@
+<div>
+    <p>
+        Jenkins plugins can be created, and installed, that capitalize on the "SplunkQueue" Extension Point. Any installed Extension that implements the "SplunkQueue" interface will show up as a value in this list.
+    </p>
+</div>

--- a/splunk-devops/src/test/java/com/splunk/splunkjenkins/LogConsumerHandlerTest.java
+++ b/splunk-devops/src/test/java/com/splunk/splunkjenkins/LogConsumerHandlerTest.java
@@ -1,0 +1,53 @@
+package com.splunk.splunkjenkins;
+
+import java.lang.Exception;
+import java.io.IOException;
+
+import org.apache.http.HttpStatus;
+
+import shaded.splk.org.apache.http.HttpResponse;
+import shaded.splk.org.apache.http.StatusLine;
+
+import java.util.logging.Logger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.*;
+import static org.junit.Assert.*;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.instanceOf;
+
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
+
+import com.splunk.splunkjenkins.utils.LogConsumerHandler;
+import com.splunk.splunkjenkins.utils.SplunkServiceError;
+
+
+public class LogConsumerHandlerTest {
+    private static final Logger LOG = Logger.getLogger(LogConsumerHandlerTest.class.getName());
+
+    @Test
+    public void test502Error() throws IOException, InterruptedException {
+        LOG.info("Running test502Error in LogConsumerHandlerTest");
+
+        // Configure mocked objects
+        HttpResponse mockHttpResponse = mock(HttpResponse.class);
+        StatusLine mockStatusLine = mock(StatusLine.class);
+
+        // Configure mocked responses
+        when(mockHttpResponse.getStatusLine()).thenReturn(mockStatusLine);
+        when(mockStatusLine.getStatusCode()).thenReturn(HttpStatus.SC_BAD_GATEWAY);
+
+        // Analyze 502 response
+        long errorCount = 0;
+        AtomicLong counter = new AtomicLong();
+        LogConsumerHandler handler = new LogConsumerHandler(errorCount, counter);
+
+        try {
+            handler.handleResponse(mockHttpResponse);
+        } catch(Exception ex) {
+            assertThat(ex, instanceOf(SplunkServiceError.class));
+        }
+    }
+}

--- a/splunk-devops/src/test/java/com/splunk/splunkjenkins/LogConsumerTest.java
+++ b/splunk-devops/src/test/java/com/splunk/splunkjenkins/LogConsumerTest.java
@@ -1,0 +1,98 @@
+package com.splunk.splunkjenkins;
+
+import java.io.IOException;
+
+import shaded.splk.org.apache.http.HttpResponse;
+import shaded.splk.org.apache.http.StatusLine;
+import shaded.splk.org.apache.http.HttpStatus;
+import shaded.splk.org.apache.http.client.HttpClient;
+import shaded.splk.org.apache.http.client.methods.HttpPost;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Logger;
+
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import com.splunk.splunkjenkins.utils.LogConsumer;
+import com.splunk.splunkjenkins.model.EventType;
+import com.splunk.splunkjenkins.model.EventRecord;
+import com.splunk.splunkjenkins.utils.SplunkQueue;
+import com.splunk.splunkjenkins.utils.DefaultSplunkQueue;
+
+import static com.splunk.splunkjenkins.utils.LogEventHelper.buildPost;
+
+public class LogConsumerTest {
+    private static final Logger LOG = Logger.getLogger(LogConsumerTest.class.getName());
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Before
+    public void setUp() throws Exception {
+        // Configure dummy Splunk installation
+        SplunkJenkinsInstallation splunkJenkinsInstallation = new SplunkJenkinsInstallation();
+        splunkJenkinsInstallation.setEnabled(true);
+        SplunkJenkinsInstallation.initOnSlave(splunkJenkinsInstallation);
+    }
+
+    @Test
+    public void test502Retry() throws Exception {
+        // Configure mocked objects
+        HttpClient mockHttpClient = mock(HttpClient.class);
+        HttpPost mockHttpPost = mock(HttpPost.class);
+        HttpResponse mockHttpResponse = mock(HttpResponse.class);
+        StatusLine mockStatusLine = mock(StatusLine.class);
+
+        // Configure mocked responses
+        when(mockHttpClient.execute(any(HttpPost.class))).thenReturn(mockHttpResponse);
+        when(mockHttpResponse.getStatusLine()).thenReturn(mockStatusLine);
+        when(mockStatusLine.getStatusCode()).thenReturn(HttpStatus.SC_BAD_GATEWAY);
+
+        // Verify mocked 502 response set-up
+        HttpPost testPost = buildPost(
+            new EventRecord("ping from test502Retry", EventType.LOG),
+            SplunkJenkinsInstallation.get()
+        );
+        final HttpResponse testResponse = mockHttpClient.execute(testPost);
+        assertEquals(502, testResponse.getStatusLine().getStatusCode());
+
+        // Create LogConsumer thread to test
+        SplunkQueue logQueue = new DefaultSplunkQueue(5);
+        String line = "127.0.0.1 - admin \"GET /en-US/ HTTP/1.1\"";
+        EventRecord record = new EventRecord(line, EventType.LOG);
+        boolean added = logQueue.offer(record);
+        assertTrue(added);
+        LOG.info("Added record to test queue for initialization: " + logQueue.toString());
+
+        // Start LogConsumer thread
+        LogConsumer workerThread = new LogConsumer(mockHttpClient, logQueue, new AtomicLong());
+        LogConsumer spyLogConsumer = spy(workerThread);
+        spyLogConsumer.start();
+        LOG.info("Started LogConsumer: " + logQueue.toString());
+        LOG.info(spyLogConsumer.toString());
+
+        // As LogConsumer runs, take EventRecord off of queue
+        // wait for this
+        TimeUnit.SECONDS.sleep(5);
+        LOG.info("Paused for LogConsumer: " + logQueue.toString());
+        LOG.info(spyLogConsumer.toString());
+
+        // Assert that handleRetry was called
+        verify(spyLogConsumer).handleRetry(any(IOException.class), any(EventRecord.class));
+
+        // Tear down
+        spyLogConsumer.stopTask();
+    }
+}

--- a/splunk-devops/src/test/java/com/splunk/splunkjenkins/SplunkLogServiceTest.java
+++ b/splunk-devops/src/test/java/com/splunk/splunkjenkins/SplunkLogServiceTest.java
@@ -7,11 +7,15 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
+import com.splunk.splunkjenkins.SplunkJenkinsInstallation;
 import com.splunk.splunkjenkins.model.EventType;
 import com.splunk.splunkjenkins.utils.SplunkLogService;
-import org.junit.*;
 
 import static com.splunk.splunkjenkins.SplunkConfigUtil.verifySplunkSearchResult;
+import static com.splunk.splunkjenkins.model.EventType.SLAVE_INFO;
+import static com.splunk.splunkjenkins.utils.LogEventHelper.getSlaveStats;
+
+import org.junit.*;
 import static org.junit.Assert.*;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -57,6 +61,12 @@ public class SplunkLogServiceTest extends BaseTest {
         }
         int expected = BATCH_COUNT;
         verifySplunkSearchResult(query, timestamp, expected);
+
+        // Ensure sendBatch method can run
+        Map<String, Map<String, Object>> testSlaveStats = getSlaveStats();
+        LOG.info("Test stats: " + testSlaveStats.toString());
+        LOG.info("Test stat values: " + testSlaveStats.values());
+        SplunkLogService.getInstance().sendBatch(testSlaveStats.values(), SLAVE_INFO);
     }
 
     @Test

--- a/splunk-devops/src/test/java/com/splunk/splunkjenkins/SplunkQueueTest.java
+++ b/splunk-devops/src/test/java/com/splunk/splunkjenkins/SplunkQueueTest.java
@@ -1,0 +1,248 @@
+package com.splunk.splunkjenkins;
+
+import hudson.ExtensionList;
+import hudson.util.ListBoxModel;
+import hudson.util.ListBoxModel.Option;
+
+import org.kohsuke.stapler.StaplerRequest;
+import net.sf.json.JSONObject;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.logging.Logger;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+import org.jvnet.hudson.test.TestExtension;
+import org.junit.Before;
+
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.splunk.splunkjenkins.SplunkJenkinsInstallation;
+import com.splunk.splunkjenkins.utils.SplunkQueue;
+import com.splunk.splunkjenkins.utils.DefaultSplunkQueue;
+import com.splunk.splunkjenkins.model.EventType;
+import com.splunk.splunkjenkins.model.EventRecord;
+import com.splunk.splunkjenkins.utils.SplunkLogService;
+
+// BaseTest had JenkinsRules that allows test to fire up a Jenkins instance
+public class SplunkQueueTest extends BaseTest {
+    private static final Logger LOG = Logger.getLogger(SplunkQueueTest.class.getName());
+
+    private static StaplerRequest mockRequest;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        mockRequest = mock(StaplerRequest.class);
+        given(mockRequest.bindJSON(any(Class.class), any(JSONObject.class))).willCallRealMethod();
+    }
+
+    @Test
+    public void testQueueMethods() throws Exception {
+        DefaultSplunkQueue testQueue = new DefaultSplunkQueue();
+
+        String line = "127.0.0.1 - admin \"GET /en-US/ HTTP/1.1\"";
+        EventRecord record = new EventRecord(line, EventType.LOG);
+        boolean added = testQueue.enqueue(record);
+        assertTrue(added);
+        assertEquals(1, testQueue.size());
+    }
+
+    @Test
+    public void testDefaultExtension() throws Exception {
+        // Check that expected extensions installed
+        ExtensionList<SplunkQueue> splunkQueueList = ExtensionList.lookup(SplunkQueue.class);
+        assertEquals(1, splunkQueueList.size());
+
+        ExtensionList<DefaultSplunkQueue> specificQueueList = ExtensionList.lookup(DefaultSplunkQueue.class);
+        assertEquals(1, specificQueueList.size());
+
+        // Check that queue types are available for selection
+        SplunkJenkinsInstallation globalConfig = SplunkJenkinsInstallation.get();
+        ListBoxModel configOptions = globalConfig.doFillQueueTypeItems();
+        assertEquals(1, configOptions.size());
+
+        String queueRegex = "\\b" + DefaultSplunkQueue.class.getSimpleName() + "\\b";
+        Pattern queuePattern = Pattern.compile(queueRegex);
+        Matcher queueMatch = queuePattern.matcher(configOptions.toString());
+        assertTrue(queueMatch.find());
+        
+        // Ensure default queue is as expected
+        SplunkLogService logService = SplunkLogService.getInstance();
+        assertTrue(logService.getQueue() instanceof DefaultSplunkQueue);
+        String line = "127.0.0.1 - admin \"GET /en-US/ HTTP/1.1\"";
+        EventRecord record = new EventRecord(line, EventType.LOG);
+        boolean added = logService.getQueue().enqueue(record);
+        assertTrue(added);
+    }
+
+    @Test
+    public void testAddOneQueueExtension() throws Exception {
+        // Check that expected extensions installed
+        ExtensionList<SplunkQueue> splunkQueueList = ExtensionList.lookup(SplunkQueue.class);
+        assertEquals(2, splunkQueueList.size());
+
+        ExtensionList<TestQueue1> specificQueueList = ExtensionList.lookup(TestQueue1.class);
+        assertEquals(1, specificQueueList.size());
+
+        // Check that queue types are available for selection
+        SplunkJenkinsInstallation globalConfig = SplunkJenkinsInstallation.get();
+        ListBoxModel configOptions = globalConfig.doFillQueueTypeItems();
+        assertEquals(2, configOptions.size());
+        
+        String queueRegex1 = "\\b" + DefaultSplunkQueue.class.getSimpleName() + "\\b";
+        Pattern queuePattern1 = Pattern.compile(queueRegex1);
+        Matcher queueMatch1 = queuePattern1.matcher(configOptions.toString());
+        assertTrue(queueMatch1.find());
+        String queueRegex2 = "\\b" + TestQueue1.class.getSimpleName() + "\\b";
+        Pattern queuePattern2 = Pattern.compile(queueRegex2);
+        Matcher queueMatch2 = queuePattern1.matcher(configOptions.toString());
+        assertTrue(queueMatch2.find());
+
+        // Get payload for dropdown option value for new extension
+        JSONObject testJsonObject = createConfigBinding(TestQueue1.class, configOptions);
+
+        // Update configuration
+        boolean configureResult = globalConfig.configure(mockRequest, testJsonObject);
+        assertTrue(configureResult);
+        assertTrue(globalConfig.isValid());
+
+        // Ask SplunkLogService what queue type is being used
+        SplunkLogService logService = SplunkLogService.getInstance();
+        assertTrue(logService.getQueue() instanceof TestQueue1);
+
+        // Ensure new queue is working
+        EventRecord testRecord = logService.getQueue().take();
+        assertTrue(logService.getQueue().enqueue(testRecord));
+        assertTrue(logService.getQueue().offer(testRecord));
+        assertEquals(5, logService.getQueueSize());
+    }
+
+    @Test
+    public void testAddMultipleQueueExtensions() throws Exception {
+        // Check that expected extensions installed
+        ExtensionList<SplunkQueue> splunkQueueList = ExtensionList.lookup(SplunkQueue.class);
+        assertEquals(3, splunkQueueList.size());
+        assertNotNull(splunkQueueList);
+
+        ExtensionList<TestQueue2> specificQueueList = ExtensionList.lookup(TestQueue2.class);
+        assertEquals(1, specificQueueList.size());
+
+        // Check that queue types are available for selection
+        SplunkJenkinsInstallation globalConfig = SplunkJenkinsInstallation.get();
+        ListBoxModel configOptions = globalConfig.doFillQueueTypeItems();
+        assertEquals(3, configOptions.size());
+
+        String queueRegex1 = "\\b" + DefaultSplunkQueue.class.getSimpleName() + "\\b";
+        Pattern queuePattern1 = Pattern.compile(queueRegex1);
+        Matcher queueMatch1 = queuePattern1.matcher(configOptions.toString());
+        assertTrue(queueMatch1.find());
+        String queueRegex2 = "\\b" + TestQueue1.class.getSimpleName() + "\\b";
+        Pattern queuePattern2 = Pattern.compile(queueRegex2);
+        Matcher queueMatch2 = queuePattern1.matcher(configOptions.toString());
+        assertTrue(queueMatch2.find());
+        String queueRegex3 = "\\b" + TestQueue2.class.getSimpleName() + "\\b";
+        Pattern queuePattern3 = Pattern.compile(queueRegex3);
+        Matcher queueMatch3 = queuePattern1.matcher(configOptions.toString());
+        assertTrue(queueMatch3.find());
+
+        // Get payload for dropdown option value for new extension
+        JSONObject testJsonObject = createConfigBinding(TestQueue2.class, configOptions);
+
+        // Update configuration
+        boolean configureResult = globalConfig.configure(mockRequest, testJsonObject);
+        assertTrue(configureResult);
+        assertTrue(globalConfig.isValid());
+
+        // Ask SplunkLogService what queue type is being used
+        SplunkLogService logService = SplunkLogService.getInstance();
+        assertTrue(logService.getQueue() instanceof TestQueue2);
+
+        // Ensure new queue is working
+        EventRecord testRecord = logService.getQueue().take();
+        assertTrue(logService.getQueue().enqueue(testRecord));
+        assertTrue(logService.getQueue().offer(testRecord));
+        assertEquals(5, logService.getQueueSize());
+    }
+
+    private JSONObject createConfigBinding(Class queueClass, ListBoxModel configOptions){
+        String selectOptionName = queueClass.getSimpleName();
+        String selectOptionValue = "";
+        for (ListBoxModel.Option dropDownChoice : configOptions){
+            if(dropDownChoice.name.equals(selectOptionName)){
+                selectOptionValue = dropDownChoice.value;
+                LOG.info("Choosing dropdown option: " + dropDownChoice.name + "=" + selectOptionValue);
+                break;
+            }
+        }
+
+        // Select queue type
+        JSONObject testJsonObject = new JSONObject();
+        testJsonObject.put("enabled", true);
+        testJsonObject.put("queueType", selectOptionValue);
+
+        return testJsonObject;
+    }
+
+    @TestExtension({"testAddOneQueueExtension", "testAddMultipleQueueExtensions"})
+    public static class TestQueue1 implements SplunkQueue {
+        private static final Logger LOG = Logger.getLogger(TestQueue1.class.getName());
+        private int capacity = 5;
+
+        public TestQueue1(){
+            LOG.info("TestQueue1");
+        }
+
+        public TestQueue1(int capacity) {
+            this.capacity = capacity;
+        }
+
+        @Override
+        public void clear(){
+            LOG.info("TestQueue1 | clear");
+        }
+
+        @Override
+        public boolean enqueue(EventRecord record){
+            LOG.info("TestQueue1 | enqueue");
+            return true;
+        }
+
+        @Override
+        public boolean offer(EventRecord record){
+            LOG.info("TestQueue1 | offer");
+            return true;
+        }
+
+        @Override
+        public int size(){
+            LOG.info("TestQueue1 | size");
+            return capacity;
+        }
+
+        @Override
+        public EventRecord take() throws InterruptedException{
+            LOG.info("TestQueue1 | take");
+            String line = "127.0.0.1 - admin \"GET /en-US/ HTTP/1.1\"";
+            EventRecord record = new EventRecord(line, EventType.LOG);
+            return record;
+        }
+    }
+
+    @TestExtension("testAddMultipleQueueExtensions")
+    public static class TestQueue2 extends TestQueue1 {
+        private static final Logger LOG = Logger.getLogger(TestQueue2.class.getName());
+        private int capacity = 10;
+        
+        public TestQueue2(){
+            super(10);
+            LOG.info("TestQueue2");
+        }
+    }
+}


### PR DESCRIPTION
Changes were made to ease an issue with data getting dropped immediately when encountering "502" errors that occur upon sending information to Splunk. Errors with a "502" status code are now classified as a [`SplunkServiceError`](https://github.com/nrs87/splunk-devops-plugin/blob/master/splunk-devops/src/main/java/com/splunk/splunkjenkins/utils/SplunkServiceError.java). In practice, inputs to the HEC endpoint need more resiliency, they need to retry rather than drop data at the first rejection.
* a `SplunkServiceError` is retried [like so](https://github.com/nrs87/splunk-devops-plugin/blob/master/splunk-devops/src/main/java/com/splunk/splunkjenkins/utils/LogConsumer.java#L90-L93). The method `handleRetry ` is called [here](https://github.com/nrs87/splunk-devops-plugin/blob/master/splunk-devops/src/main/java/com/splunk/splunkjenkins/utils/LogConsumer.java#L68) when [`buildPost`](https://github.com/nrs87/splunk-devops-plugin/blob/master/splunk-devops/src/main/java/com/splunk/splunkjenkins/utils/LogEventHelper.java#L91-L125) does [not succeed](https://github.com/nrs87/splunk-devops-plugin/blob/master/splunk-devops/src/main/java/com/splunk/splunkjenkins/utils/LogConsumer.java#L55) and the event is not part of the list of [`giveUpExceptions`](https://github.com/nrs87/splunk-devops-plugin/blob/master/splunk-devops/src/main/java/com/splunk/splunkjenkins/utils/LogConsumer.java#L32-L35).

Changes were also made to try and ease the contention with the default message queue, in hopes this would also help prevent data loss. Threads are now asked to wait for a few seconds when space in the queue is unavailable.
* when inserting Splunk data into the queue, threads will [wait for space to become available](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/LinkedBlockingQueue.html#offer-E-long-java.util.concurrent.TimeUnit-), timing out after a few seconds
* the queue lock is asked to favor threads that have been [waiting the longest](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/locks/ReentrantLock.html#ReentrantLock-boolean-)

The message queue itself was abstracted out and a [SplunkQueue](https://github.com/nrs87/splunk-devops-plugin/blob/master/splunk-devops/src/main/java/com/splunk/splunkjenkins/utils/SplunkQueue.java) interface was created.
* Created interface `SplunkQueue`
   * Now a parameter for `LogConsumer` [initialization](https://github.com/nrs87/splunk-devops-plugin/blob/master/splunk-devops/src/main/java/com/splunk/splunkjenkins/utils/LogConsumer.java#L38)
   * `SplunkLogService` now utilizes a `SplunkQueue` [variable](https://github.com/nrs87/splunk-devops-plugin/blob/master/splunk-devops/src/main/java/com/splunk/splunkjenkins/utils/SplunkLogService.java#L37)
* Created `DefaultSplunkQueue` that implements `SplunkQueue`
   * `DefaultSplunkQueue` class houses an `enqueue` [method](https://github.com/nrs87/splunk-devops-plugin/blob/master/splunk-devops/src/main/java/com/splunk/splunkjenkins/utils/DefaultSplunkQueue.java#L33)
   * `SplunkLogService` still has its own `enqueue` [method](https://github.com/nrs87/splunk-devops-plugin/blob/master/splunk-devops/src/main/java/com/splunk/splunkjenkins/utils/SplunkLogService.java#L186) that handles calling `DefaultSplunkQueue.enqueue`, as well as handling the worker threads

SplunkQueue interface marked as an extensible components in Jenkins ([ExtensionPoint](http://javadoc.jenkins.io/hudson/ExtensionPoint.html)). Having the Splunk Jenkins plugin define this extension point allows other plugins to contribute implementations ([Extension](http://javadoc.jenkins.io/hudson/Extension.html)). As a result, this plugin will not have to be forked and altered in order to update the message queue implementation. Tested this feature using [TestExtension](http://javadoc.jenkins.io/component/jenkins-test-harness/index.html?org/jvnet/hudson/test/TestExtension.html).