### PR TITLE
accept standard cookies

### DIFF
--- a/splunk-devops/src/main/java/com/splunk/splunkjenkins/utils/SplunkLogService.java
+++ b/splunk-devops/src/main/java/com/splunk/splunkjenkins/utils/SplunkLogService.java
@@ -6,6 +6,8 @@ import com.splunk.splunkjenkins.model.EventRecord;
 import com.splunk.splunkjenkins.model.EventType;
 import shaded.splk.org.apache.http.HttpResponse;
 import shaded.splk.org.apache.http.client.HttpClient;
+import shaded.splk.org.apache.http.client.config.CookieSpecs;
+import shaded.splk.org.apache.http.client.config.RequestConfig;
 import shaded.splk.org.apache.http.config.Registry;
 import shaded.splk.org.apache.http.config.RegistryBuilder;
 import shaded.splk.org.apache.http.config.SocketConfig;
@@ -69,7 +71,10 @@ public class SplunkLogService {
                 return keepAliveTime;
             }
         };
-        this.client = HttpClients.custom().setConnectionManager(this.connMgr).setKeepAliveStrategy(myStrategy).build();
+        this.client = HttpClients.custom()
+            .setConnectionManager(this.connMgr).setKeepAliveStrategy(myStrategy)
+            .setDefaultRequestConfig(RequestConfig.custom().setCookieSpec(CookieSpecs.STANDARD).build())
+            .build();
     }
 
     public static SplunkLogService getInstance() {


### PR DESCRIPTION
We recently moved to a new Splunk server with a load balancer in front of it. The load balancer sets a cookie in the response header which results in an ugly warning in the Jenkins log such as:
```
Jan 08, 2019 3:46:59 PM shaded.splk.org.apache.http.client.protocol.ResponseProcessCookies processCookies
WARNING: Invalid cookie header: "Set-Cookie: AWSALB=longPseudoRandomString; Expires=Tue, 15 Jan 2019 15:46:49 GMT; Path=/". Invalid 'expires' attribute: Tue, 15 Jan 2019 15:46:49 GMT                                                                                                                                
```
As there can be a lot of these, it makes the logs hard to read. According to the wise Internet the reason is that the HttpClient class doesn't handle cookies well by default; with this patch the splunk-plugin accepts the cookies without a warning.

The meat of the change is line 76. Lines 74, 75 and 77 are just a reformatting of the old line 72.