### PR TITLE
Use system properties for proxy configuration

### DIFF
--- a/splunk-devops/src/main/java/com/splunk/splunkjenkins/utils/SplunkLogService.java
+++ b/splunk-devops/src/main/java/com/splunk/splunkjenkins/utils/SplunkLogService.java
@@ -73,8 +73,10 @@ public class SplunkLogService {
             }
         };
         this.client = HttpClients.custom()
-            .setConnectionManager(this.connMgr).setKeepAliveStrategy(myStrategy)
+            .setConnectionManager(this.connMgr)
+            .setKeepAliveStrategy(myStrategy)
             .setDefaultRequestConfig(RequestConfig.custom().setCookieSpec(CookieSpecs.STANDARD).build())
+            .useSystemProperties()
             .build();
     }
 


### PR DESCRIPTION
The Splunk plugin for jenkins doesn't appear to use proxy settings
configured via the jvm args: http.ProxyHost, https.ProxyHost,
http.ProxyPort, https.ProxyPort, etc.

The Apache HttpClient requires that a proxy be either manually set, or
alternatively it can use the proxy settings provided to the jvm by the
standard proxy configuration properties. To use the proxy configuration
properties it is required to build a default system HttpClient, or to
use the `.useSystemProperties()` method of the HttpClientBuilder class.

Use the system properties to configure the client unless otherwise
overridden.