### PR TITLE
Trim whitespaces before empty check

### DIFF
--- a/splunk-devops-extend/src/main/java/com/splunk/splunkjenkins/console/LabelConsoleLineStream.java
+++ b/splunk-devops-extend/src/main/java/com/splunk/splunkjenkins/console/LabelConsoleLineStream.java
@@ -45,7 +45,7 @@ public class LabelConsoleLineStream extends FilterOutputStream {
         String line = decoder.decodeLine(branch.getBuffer(), branch.size());
         // reuse the buffer under normal circumstances
         branch.reset();
-        if (line != null && !"".equals(line)) {
+        if (line != null && !"".equals(line.trim())) {
             line = ANSI_COLOR_ESCAPE.matcher(line).replaceAll("");
             EventRecord record = new EventRecord(line, CONSOLE_LOG);
             record.setSource(source);

--- a/splunk-devops-extend/src/main/java/com/splunk/splunkjenkins/console/LabelConsoleLineStream.java
+++ b/splunk-devops-extend/src/main/java/com/splunk/splunkjenkins/console/LabelConsoleLineStream.java
@@ -10,6 +10,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang.StringUtils;
+
 import static com.splunk.splunkjenkins.Constants.CONSOLE_TEXT_SINGLE_LINE_MAX_LENGTH;
 import static com.splunk.splunkjenkins.model.EventType.CONSOLE_LOG;
 
@@ -45,7 +47,7 @@ public class LabelConsoleLineStream extends FilterOutputStream {
         String line = decoder.decodeLine(branch.getBuffer(), branch.size());
         // reuse the buffer under normal circumstances
         branch.reset();
-        if (line != null && !"".equals(line.trim())) {
+        if (line != null && StringUtils.isNotBlank(line)) {
             line = ANSI_COLOR_ESCAPE.matcher(line).replaceAll("");
             EventRecord record = new EventRecord(line, CONSOLE_LOG);
             record.setSource(source);


### PR DESCRIPTION
Splunk does not accept events containing only whitespaces. Splunk will reject event containing only whitespaces and following events on sent batch are discarded. -> trim line before checking if it's empty to avoid such lines to be sent to splunk.