### PR TITLE
Publishing more granular queue time to Splunk

### DIFF
--- a/doc/extension.md
+++ b/doc/extension.md
@@ -33,14 +33,12 @@ Plugin implements some interfaces and marks the implementation to use annotation
     when user made changes to jenkins config (either plugin config or job config), record the config xml. disabled by default until user add jenkins_config.monitoring=true into metadata config
 #### [ItemListener](http://javadoc.jenkins-ci.org/hudson/model/listeners/RunListener.html)
 	similar to SaveableListener but for Job only, it has finer grained audit event. used to capture job created, renamed, copied and deleted
-
 #### [QueueListener](http://javadoc.jenkins-ci.org/hudson/model/queue/QueueListener.html)
-	listen for onEnterWaiting and onLeft and record the job queueTime and jenkins metrics
+	listen for onEnterWaiting, onLeaveWaiting, onEnterBlocked, onLeaveBlocked, onEnterBuildable, onLeavebBuildable, and onLeft. Record the job queueTime in each of the phase along with other jenkins metrics and reports to Splunk. 
 #### [RunListener](http://javadoc.jenkins-ci.org/hudson/model/listeners/RunListener.html)
 	listen for onStarted and onCompleted, and extract upstream job, build cause, scm, job result, and invoke DSL if defined
 #### [ComputerListener](http://javadoc.jenkins-ci.org/hudson/slaves/ComputerListener.html)
 	record slave online, offline, temporarilyOffline, and launchFailure
-
 ## [Notifier](http://javadoc.jenkins-ci.org/hudson/tasks/Notifier.html)
     Contribute to post build step, user can custom the logs to send to splunk in addition to what we have in Groovy DSL.
 

--- a/doc/extension.md
+++ b/doc/extension.md
@@ -26,6 +26,7 @@ Plugin implements some interfaces and marks the implementation to use annotation
 ```
     it will call fireOnDeleted to notify all ItemListeners
 
+
 ## Listeners list
 #### [SecurityListener](http://javadoc.jenkins-ci.org/jenkins/security/SecurityListener.html)
     record user login/logout and failedToLogIn events

--- a/splunk-devops/src/main/java/com/splunk/splunkjenkins/Constants.java
+++ b/splunk-devops/src/main/java/com/splunk/splunkjenkins/Constants.java
@@ -19,6 +19,11 @@ public class Constants {
     public static final String LOG_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
     public final static String SLAVE_TAG_NAME = "slave";
     public final static String QUEUE_TAG_NAME = "queue";
+    public final static String ENQUEUE_TAG_NAME = "enqueue";
+    public final static String DEQUEUE_TAG_NAME = "dequeue";
+    public final static String BUILDABLE_PHASE_NAME = "buildable";
+    public final static String BLOCKED_PHASE_NAME = "blocked";
+    public final static String WAITING_PHASE_NAME = "waiting";
     public final static String QUEUE_WAITING_ITEM_NAME = "queue_item";
     public static final String JOB_EVENT_TAG_NAME = "job_event";
     public static final String JOB_EVENT_MONITOR = "job_monitor";

--- a/splunk-devops/src/main/java/com/splunk/splunkjenkins/listeners/LoggingQueueListener.java
+++ b/splunk-devops/src/main/java/com/splunk/splunkjenkins/listeners/LoggingQueueListener.java
@@ -6,14 +6,11 @@ import com.splunk.splunkjenkins.Constants;
 import com.splunk.splunkjenkins.SplunkJenkinsInstallation;
 import com.splunk.splunkjenkins.utils.SplunkLogService;
 import hudson.Extension;
-import hudson.model.Item;
 import hudson.model.Queue;
 import hudson.model.queue.QueueListener;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Logger;
 
 import static com.splunk.splunkjenkins.model.EventType.QUEUE_INFO;
 import static com.splunk.splunkjenkins.utils.LogEventHelper.getMasterStats;
@@ -37,52 +34,50 @@ public class LoggingQueueListener extends QueueListener {
     // Cache to keep track of queue time
     private final static Cache<Long, Float> cache = CacheBuilder.newBuilder()
             .maximumSize(3000).build();
-    //To keep track of blocked events timestamp
-    private final static ConcurrentHashMap<Long, Long> blockedQueue = new ConcurrentHashMap<Long, Long>();
-    //To keep track of buildable events timestamp
-    private final static ConcurrentHashMap<Long, Long> buildableQueue = new ConcurrentHashMap<Long, Long>();
-    //To keep track of waiting events timestamp
-    private final static ConcurrentHashMap<Long, Long> waitingQueue = new ConcurrentHashMap<Long, Long>();
+    //To keep track of events timestamp for the queue phases like waiting, blocked and buildable
+    private final static ConcurrentHashMap<Long, Long> queuePhase = new ConcurrentHashMap<Long, Long>();
 
     @Override
     public void onEnterWaiting(Queue.WaitingItem wi) {
-        sendToSplunkOnEnter(wi.task, wi.getId(), waitingQueue, Constants.ENQUEUE_TAG_NAME);
+        sendToSplunkOnEnter(wi.task, wi.getId(), Constants.ENQUEUE_TAG_NAME);
     }
 
     @Override
     public void onLeaveWaiting(Queue.WaitingItem wi) {
-        sendToSplunkOnLeft(wi.task, wi.getId(), waitingQueue,
+        sendToSplunkOnLeft(wi.task, wi.getId(),
                 Constants.WAITING_PHASE_NAME, wi.getWhy(), wi.getInQueueSince());
     }
 
     @Override
     public void onEnterBlocked(Queue.BlockedItem bi) {
-        sendToSplunkOnEnter(bi.task, bi.getId(), blockedQueue, Constants.BLOCKED_PHASE_NAME);
+        sendToSplunkOnEnter(bi.task, bi.getId(), Constants.BLOCKED_PHASE_NAME);
     }
 
     @Override
     public void onLeaveBlocked(Queue.BlockedItem bi) {
-        sendToSplunkOnLeft(bi.task, bi.getId(), blockedQueue,
+        sendToSplunkOnLeft(bi.task, bi.getId(),
                 Constants.BLOCKED_PHASE_NAME, bi.getWhy(), bi.getInQueueSince());
     }
 
     @Override
     public void onEnterBuildable(Queue.BuildableItem bi) {
-        sendToSplunkOnEnter(bi.task, bi.getId(), buildableQueue, Constants.BUILDABLE_PHASE_NAME);
+        sendToSplunkOnEnter(bi.task, bi.getId(), Constants.BUILDABLE_PHASE_NAME);
 
     }
 
     @Override
     public void onLeaveBuildable(Queue.BuildableItem bi) {
-        sendToSplunkOnLeft(bi.task, bi.getId(), buildableQueue,
+        sendToSplunkOnLeft(bi.task, bi.getId(),
                 Constants.BUILDABLE_PHASE_NAME, bi.getWhy(), bi.getInQueueSince());
     }
 
     @Override
     public void onLeft(Queue.LeftItem li) {
-        Float queueTime = sendToSplunkOnLeft(li.task, li.getId(), buildableQueue,
+        Float queueTime = sendToSplunkOnLeft(li.task, li.getId(),
                 Constants.DEQUEUE_TAG_NAME, li.getWhy(), li.getInQueueSince());
-        //Storing it in the cache to access it later
+        //Removing it from the map
+        queuePhase.remove(li.getId());
+        //Storing i]t in the cache to access it later
         cache.put(li.getId(), queueTime);
 
     }
@@ -131,12 +126,11 @@ public class LoggingQueueListener extends QueueListener {
      * Send build queue meta data to splunk on entering to any of the queue phases
      * like buildable, blocked and waiting
      *
-     * @param task task associated with a queue
-     * @param id id of the queue
-     * @param queue map used to store the time stamp of the queue phases
+     * @param task      task associated with a queue
+     * @param id        id of the queue
      * @param eventType type of the queue phase
      */
-    private void sendToSplunkOnEnter(Queue.Task task, Long id, ConcurrentHashMap queue, String eventType) {
+    private void sendToSplunkOnEnter(Queue.Task task, Long id, String eventType) {
         if (SplunkJenkinsInstallation.get().isEventDisabled(QUEUE_INFO)) {
             return;
         }
@@ -144,9 +138,9 @@ public class LoggingQueueListener extends QueueListener {
         if (SplunkJenkinsInstallation.get().isJobIgnored(name)) {
             return;
         }
-        queue.put(id, System.currentTimeMillis());
+        queuePhase.put(id, System.currentTimeMillis());
         String eventTypeEnqueue;
-        if(eventType.equals(Constants.ENQUEUE_TAG_NAME)) {
+        if (eventType.equals(Constants.ENQUEUE_TAG_NAME)) {
             eventTypeEnqueue = eventType;
         } else {
             eventTypeEnqueue = Constants.ENQUEUE_TAG_NAME + "_" + eventType;
@@ -160,15 +154,14 @@ public class LoggingQueueListener extends QueueListener {
      * Send queue time and other meta data to splunk on leaving from any of the
      * queue phases like buildable, blocked and waiting
      *
-     * @param task task associated with a queue
-     * @param id id of the queue
-     * @param queue map used to store the time stamp of the queue phases
-     * @param eventType type of the queue phase
-     * @param message message of the slave available in the queue
+     * @param task         task associated with a queue
+     * @param id           id of the queue
+     * @param eventType    type of the queue phase
+     * @param message      message of the slave available in the queue
      * @param inQueueSince time
      * @return
      */
-    private Float sendToSplunkOnLeft(Queue.Task task, Long id, ConcurrentHashMap queue, String eventType, String message, Long inQueueSince) {
+    private Float sendToSplunkOnLeft(Queue.Task task, Long id, String eventType, String message, Long inQueueSince) {
         if (SplunkJenkinsInstallation.get().isEventDisabled(QUEUE_INFO)) {
             return 0f;
         }
@@ -181,7 +174,7 @@ public class LoggingQueueListener extends QueueListener {
         String eventTypeDequeue;
         String durationName;
         //Customize queue time for phases Vs on left at last
-        if(eventType.equals(Constants.DEQUEUE_TAG_NAME)) {
+        if (eventType.equals(Constants.DEQUEUE_TAG_NAME)) {
             eventTypeDequeue = eventType;
             durationName = "queue_time";
             //Calculate queue time for on left from getInQueueSince available in the queueItem
@@ -190,7 +183,7 @@ public class LoggingQueueListener extends QueueListener {
             eventTypeDequeue = Constants.DEQUEUE_TAG_NAME + "_" + eventType;
             durationName = eventType + "_time";
             //Calculate duration for the phase from the stored HashMap in this object.
-            queueTimeDuration = getDurationInQueuePhase(id, queue);
+            queueTimeDuration = getDurationInQueuePhase(id);
         }
 
         Map event = getCommonEvents(eventTypeDequeue, id, name);
@@ -203,19 +196,18 @@ public class LoggingQueueListener extends QueueListener {
 
     /**
      * Calculate the time spent in a particular phase
+     *
      * @param id id of the item in queue
-     * @param queueType type of queue
      * @return time duration spent in a particular phase
      */
-    private Float  getDurationInQueuePhase(Long id, Map<Long, Long> queueType) {
-        Long startTime = queueType.get(id);
+    private Float getDurationInQueuePhase(Long id) {
+        Long startTime = queuePhase.get(id);
         Float durationInPhase;
         if (startTime == null) {
             //the queue has been garbage collected or jenkins has restarted
             durationInPhase = 0f;
         } else {
-            durationInPhase = (System.currentTimeMillis() - startTime)/1000f;
-            queueType.remove(id);
+            durationInPhase = (System.currentTimeMillis() - startTime) / 1000f;
         }
         return durationInPhase;
     }

--- a/splunk-devops/src/main/java/com/splunk/splunkjenkins/listeners/LoggingQueueListener.java
+++ b/splunk-devops/src/main/java/com/splunk/splunkjenkins/listeners/LoggingQueueListener.java
@@ -146,7 +146,7 @@ public class LoggingQueueListener extends QueueListener {
         }
         queue.put(id, System.currentTimeMillis());
         String eventTypeEnqueue;
-        if(eventType == Constants.ENQUEUE_TAG_NAME) {
+        if(eventType.equals(Constants.ENQUEUE_TAG_NAME)) {
             eventTypeEnqueue = eventType;
         } else {
             eventTypeEnqueue = Constants.ENQUEUE_TAG_NAME + "_" + eventType;
@@ -181,7 +181,7 @@ public class LoggingQueueListener extends QueueListener {
         String eventTypeDequeue;
         String durationName;
         //Customize queue time for phases Vs on left at last
-        if(eventType == Constants.DEQUEUE_TAG_NAME) {
+        if(eventType.equals(Constants.DEQUEUE_TAG_NAME)) {
             eventTypeDequeue = eventType;
             durationName = "queue_time";
             //Calculate queue time for on left from getInQueueSince available in the queueItem

--- a/splunk-devops/src/main/java/com/splunk/splunkjenkins/listeners/LoggingQueueListener.java
+++ b/splunk-devops/src/main/java/com/splunk/splunkjenkins/listeners/LoggingQueueListener.java
@@ -6,10 +6,14 @@ import com.splunk.splunkjenkins.Constants;
 import com.splunk.splunkjenkins.SplunkJenkinsInstallation;
 import com.splunk.splunkjenkins.utils.SplunkLogService;
 import hudson.Extension;
+import hudson.model.Item;
 import hudson.model.Queue;
 import hudson.model.queue.QueueListener;
 
+import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Logger;
 
 import static com.splunk.splunkjenkins.model.EventType.QUEUE_INFO;
 import static com.splunk.splunkjenkins.utils.LogEventHelper.getMasterStats;
@@ -30,43 +34,57 @@ import static com.splunk.splunkjenkins.utils.LogEventHelper.getMasterStats;
 @SuppressWarnings("unused")
 @Extension
 public class LoggingQueueListener extends QueueListener {
+    // Cache to keep track of queue time
     private final static Cache<Long, Float> cache = CacheBuilder.newBuilder()
             .maximumSize(3000).build();
+    //To keep track of blocked events timestamp
+    private final static ConcurrentHashMap<Long, Long> blockedQueue = new ConcurrentHashMap<Long, Long>();
+    //To keep track of buildable events timestamp
+    private final static ConcurrentHashMap<Long, Long> buildableQueue = new ConcurrentHashMap<Long, Long>();
+    //To keep track of waiting events timestamp
+    private final static ConcurrentHashMap<Long, Long> waitingQueue = new ConcurrentHashMap<Long, Long>();
 
     @Override
     public void onEnterWaiting(Queue.WaitingItem wi) {
-        if (SplunkJenkinsInstallation.get().isEventDisabled(QUEUE_INFO)) {
-            return;
-        }
-        String name = getTaskName(wi.task);
-        if (SplunkJenkinsInstallation.get().isJobIgnored(name)) {
-            return;
-        }
-        Map event = getMasterStats();
-        event.put("item", name);
-        event.put(Constants.TAG, Constants.QUEUE_TAG_NAME);
-        event.put("type", "enqueue");
-        SplunkLogService.getInstance().send(event, QUEUE_INFO);
+        sendToSplunkOnEnter(wi.task, wi.getId(), waitingQueue, Constants.ENQUEUE_TAG_NAME);
+    }
+
+    @Override
+    public void onLeaveWaiting(Queue.WaitingItem wi) {
+        sendToSplunkOnLeft(wi.task, wi.getId(), waitingQueue,
+                Constants.WAITING_PHASE_NAME, wi.getWhy(), wi.getInQueueSince());
+    }
+
+    @Override
+    public void onEnterBlocked(Queue.BlockedItem bi) {
+        sendToSplunkOnEnter(bi.task, bi.getId(), blockedQueue, Constants.BLOCKED_PHASE_NAME);
+    }
+
+    @Override
+    public void onLeaveBlocked(Queue.BlockedItem bi) {
+        sendToSplunkOnLeft(bi.task, bi.getId(), blockedQueue,
+                Constants.BLOCKED_PHASE_NAME, bi.getWhy(), bi.getInQueueSince());
+    }
+
+    @Override
+    public void onEnterBuildable(Queue.BuildableItem bi) {
+        sendToSplunkOnEnter(bi.task, bi.getId(), buildableQueue, Constants.BUILDABLE_PHASE_NAME);
+
+    }
+
+    @Override
+    public void onLeaveBuildable(Queue.BuildableItem bi) {
+        sendToSplunkOnLeft(bi.task, bi.getId(), buildableQueue,
+                Constants.BUILDABLE_PHASE_NAME, bi.getWhy(), bi.getInQueueSince());
     }
 
     @Override
     public void onLeft(Queue.LeftItem li) {
-        if (SplunkJenkinsInstallation.get().isEventDisabled(QUEUE_INFO)) {
-            return;
-        }
-        String name = getTaskName(li.task);
-        if (SplunkJenkinsInstallation.get().isJobIgnored(name)) {
-            return;
-        }
-        float queueTime = (System.currentTimeMillis() - li.getInQueueSince()) / 1000f;
+        Float queueTime = sendToSplunkOnLeft(li.task, li.getId(), buildableQueue,
+                Constants.DEQUEUE_TAG_NAME, li.getWhy(), li.getInQueueSince());
+        //Storing it in the cache to access it later
         cache.put(li.getId(), queueTime);
-        Map event = getMasterStats();
-        event.put("item", name);
-        event.put(Constants.TAG, Constants.QUEUE_TAG_NAME);
-        event.put("queue_id", li.getId());
-        event.put("queue_time", queueTime);
-        event.put("type", "dequeue");
-        SplunkLogService.getInstance().send(event, QUEUE_INFO);
+
     }
 
     /**
@@ -84,11 +102,126 @@ public class LoggingQueueListener extends QueueListener {
     }
 
     public static Float getQueueTime(Long Id) {
-        Float queueTime= cache.getIfPresent(Id);
+        Float queueTime = cache.getIfPresent(Id);
         if (queueTime == null) {
             //the queue has been garbage collected
             queueTime = 0f;
         }
+        return queueTime;
+    }
+
+    /**
+     * Generate common metadata to be reported across all the different phases of the queue
+     *
+     * @param type     type of the queue phase
+     * @param id       identifier of the queue
+     * @param itemName job name associated with the queue
+     * @return generated events to be published to splunk
+     */
+    private Map getCommonEvents(String type, Long id, String itemName) {
+        Map event = getMasterStats();
+        event.put("type", type);
+        event.put(Constants.TAG, Constants.QUEUE_TAG_NAME);
+        event.put("queue_id", id);
+        event.put("item", itemName);
+        return event;
+    }
+
+    /**
+     * Send build queue meta data to splunk on entering to any of the queue phases
+     * like buildable, blocked and waiting
+     *
+     * @param task task associated with a queue
+     * @param id id of the queue
+     * @param queue map used to store the time stamp of the queue phases
+     * @param eventType type of the queue phase
+     */
+    private void sendToSplunkOnEnter(Queue.Task task, Long id, ConcurrentHashMap queue, String eventType) {
+        if (SplunkJenkinsInstallation.get().isEventDisabled(QUEUE_INFO)) {
+            return;
+        }
+        String name = getTaskName(task);
+        if (SplunkJenkinsInstallation.get().isJobIgnored(name)) {
+            return;
+        }
+        queue.put(id, System.currentTimeMillis());
+        String eventTypeEnqueue;
+        if(eventType == Constants.ENQUEUE_TAG_NAME) {
+            eventTypeEnqueue = eventType;
+        } else {
+            eventTypeEnqueue = Constants.ENQUEUE_TAG_NAME + "_" + eventType;
+        }
+        Map event = getCommonEvents(eventTypeEnqueue, id, name);
+        SplunkLogService.getInstance().send(event, QUEUE_INFO);
+
+    }
+
+    /**
+     * Send queue time and other meta data to splunk on leaving from any of the
+     * queue phases like buildable, blocked and waiting
+     *
+     * @param task task associated with a queue
+     * @param id id of the queue
+     * @param queue map used to store the time stamp of the queue phases
+     * @param eventType type of the queue phase
+     * @param message message of the slave available in the queue
+     * @param inQueueSince time
+     * @return
+     */
+    private Float sendToSplunkOnLeft(Queue.Task task, Long id, ConcurrentHashMap queue, String eventType, String message, Long inQueueSince) {
+        if (SplunkJenkinsInstallation.get().isEventDisabled(QUEUE_INFO)) {
+            return 0f;
+        }
+        String name = getTaskName(task);
+        if (SplunkJenkinsInstallation.get().isJobIgnored(name)) {
+            return 0f;
+        }
+
+        float queueTimeDuration;
+        String eventTypeDequeue;
+        String durationName;
+        //Customize queue time for phases Vs on left at last
+        if(eventType == Constants.DEQUEUE_TAG_NAME) {
+            eventTypeDequeue = eventType;
+            durationName = "queue_time";
+            //Calculate queue time for on left from getInQueueSince available in the queueItem
+            queueTimeDuration = getQueueTime(id, inQueueSince);
+        } else {
+            eventTypeDequeue = Constants.DEQUEUE_TAG_NAME + "_" + eventType;
+            durationName = eventType + "_time";
+            //Calculate duration for the phase from the stored HashMap in this object.
+            queueTimeDuration = getDurationInQueuePhase(id, queue);
+        }
+
+        Map event = getCommonEvents(eventTypeDequeue, id, name);
+        event.put(durationName, queueTimeDuration);
+        event.put("message", message);
+
+        SplunkLogService.getInstance().send(event, QUEUE_INFO);
+        return queueTimeDuration;
+    }
+
+    /**
+     * Calculate the time spent in a particular phase
+     * @param id id of the item in queue
+     * @param queueType type of queue
+     * @return time duration spent in a particular phase
+     */
+    private Float  getDurationInQueuePhase(Long id, Map<Long, Long> queueType) {
+        Long startTime = queueType.get(id);
+        Float durationInPhase;
+        if (startTime == null) {
+            //the queue has been garbage collected or jenkins has restarted
+            durationInPhase = 0f;
+        } else {
+            durationInPhase = (System.currentTimeMillis() - startTime)/1000f;
+            queueType.remove(id);
+        }
+        return durationInPhase;
+    }
+
+    private Float getQueueTime(Long id, Long inqueueSince) {
+        float queueTime = (System.currentTimeMillis() - inqueueSince) / 1000f;
         return queueTime;
     }
 


### PR DESCRIPTION
Queue time is currently calculated when the item entering queue and when the item leaving the queue and published to Splunk. This method of calculation included queue time of following scenarios as well.

1. Github polling (Eg: When you enable github polling in your job)
2. Jobs waiting indefinitely to bring up a slave with incorrectly configured Cloud or labels
3. Jobs that are waiting for previously executing jobs. In this case queue time is an accumulated waiting time of previous executed jobs

The current queue time calculation approach doesn't provide enough data to distinguish above scenarios and excluded them appropriately in the Splunk dashboard especially when calculating average queue time or TP90 over a certain period of time for a Jenkins farm.

According to QueueListener, the item goes through different phases like waiting, blocked and buildable while on the queue. So, recording more granular time duration spent in each of these phases and publishing to Splunk would give more flexibility to exclude the noises that are mentioned above. The change proposed in this PR has been made as backward compatibility to the existing Splunk queue time metrics. As part of this, new types have been introduced to publish time duration spent in each of these phases under the same tag

The existing event type in Splunk
**enqueue**: Log when item enters in the queue
**dequeue**: Log when item left the queue along with queue time spent in the queue
This is already existing in splunk plugin. This type includes lot of noises as mentioned in above scenarios from 1-3.
Sample query:
index=jenkins_123 host=test.abc.com/test23 event_tag=queue type=enqueue
index=jenkins_123 host=test.abc.com/test23 event_tag=queue type=dequeue

There is no change to above query as part of PR.

### Newly added event types for Splunk as below:

**enqueue_buildable**: Log when item enters the buildable phase
**dequeue_buildable**: Log when item leaves buildable phase along with time spent in buildable phase and message from the slave that can be used to filter out incorrectly configured labels jobs
Sample queury: 
index=jenkins_123 host=test.abc.com/test23 event_tag=queue type=dequeue_buildable
index=jenkins_123 host=test.abc.com/test23 event_tag=queue type=enqueue_buildable
This dequeue_buildable can be used to calculate more precise queue time by excluding all the scenarios mentioned above. Message has also been added to this to exclude scenario 2 as mentioned above.

**enqueue_waiting**: Log when item enters waiting phase
**dequeue_waiting**: Log when item leaves waiting phase along with time spent in waiting phase
Sample queury:
index=jenkins_123 host=test.abc.com/test23 event_tag=queue type=dequeue_waiting
index=jenkins_123 host=test.abc.com/test23 event_tag=queue type=enqueue_waiting

**enqueue_blocked**: Log when item enters blocked phase
**dequeue_blocked**: Log when the item leaves blocked phase along with time spent in blocked phase
Sample queury:
index=jenkins_123 host=test.abc.com/test23 event_tag=queue type=dequeue_blocked
index=jenkins_123 host=test.abc.com/test23 event_tag=queue type=enqueue_blocked