### PR TITLE
Check that line is not empty after ANSI CODE replace

### DIFF
--- a/splunk-devops-extend/src/main/java/com/splunk/splunkjenkins/console/LabelConsoleLineStream.java
+++ b/splunk-devops-extend/src/main/java/com/splunk/splunkjenkins/console/LabelConsoleLineStream.java
@@ -47,7 +47,7 @@ public class LabelConsoleLineStream extends FilterOutputStream {
         String line = decoder.decodeLine(branch.getBuffer(), branch.size());
         // reuse the buffer under normal circumstances
         branch.reset();
-        if (StringUtils.isNotBlank(line)) {
+        if (line != null && StringUtils.isNotBlank(ANSI_COLOR_ESCAPE.matcher(line).replaceAll(""))) {
             line = ANSI_COLOR_ESCAPE.matcher(line).replaceAll("");
             EventRecord record = new EventRecord(line, CONSOLE_LOG);
             record.setSource(source);


### PR DESCRIPTION
If console log line contains only ANSI CODE empty line is sent to splunk because empty line
check is done before ANSI CODE replace and it causes error in sending. Line null check needed
to make sure that null line is not passed to matcher.
