### PR TITLE
Send Custom Loggers to Splunk

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.9.10 (April 5, 2022) 
+- Add CustomLoggersConfig global configuration that allows for specificying custom loggers to always send to Splunk regardless of log level, thanks to [Pierson Yieh](https://github.com/pyieh)
+
 ### 1.9.9 (January 8, 2022)
 - JENKINS-67492 fix xml entity not declared error when parsing console node
 ### 1.9.8 (December 18, 2021)

--- a/splunk-devops/pom.xml
+++ b/splunk-devops/pom.xml
@@ -221,6 +221,13 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.kohsuke.stapler</groupId>
+            <artifactId>stapler</artifactId>
+            <version>1.259</version>
+            <scope>compile</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/splunk-devops/src/main/java/com/splunk/splunkjenkins/CustomLoggerItem.java
+++ b/splunk-devops/src/main/java/com/splunk/splunkjenkins/CustomLoggerItem.java
@@ -1,0 +1,82 @@
+package com.splunk.splunkjenkins;
+
+import hudson.Extension;
+import hudson.logging.LogRecorder;
+import hudson.logging.LogRecorderManager;
+import hudson.model.Describable;
+import hudson.model.Descriptor;
+import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
+import jenkins.model.Jenkins;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+
+import java.util.Map;
+
+public class CustomLoggerItem implements Describable<CustomLoggerItem> {
+    private static final java.util.logging.Logger LOG = java.util.logging.Logger.getLogger(CustomLoggerItem.class.getName());
+
+    private static transient final LogRecorderManager logRecorderManager = Jenkins.getInstanceOrNull().getLog();
+
+    String customLoggerName;
+    LogRecorder logRecorder;
+
+    @DataBoundConstructor
+    public CustomLoggerItem(String customLoggerName) {
+        this.customLoggerName = customLoggerName;
+        logRecorder = logRecorderManager.getLogRecorder(customLoggerName);
+        if (logRecorder == null) {
+            LOG.warning("CustomLoggerItem created for non-existent custom logger with name: " + customLoggerName);
+        }
+    }
+
+    public String getCustomLoggerName() {
+        return customLoggerName;
+    }
+
+    public void setCustomLoggerName(String customLoggerName) {
+        this.customLoggerName = customLoggerName;
+    }
+
+    public LogRecorder getLogRecorder() {
+        return logRecorder;
+    }
+
+    public void setLogRecorder(LogRecorder logRecorder) {
+        this.logRecorder = logRecorder;
+    }
+
+    public String toString() {
+        return "CustomLoggerName: " + customLoggerName;
+    }
+
+    public Descriptor<CustomLoggerItem> getDescriptor() {
+        return Jenkins.getInstance().getDescriptor(getClass());
+    }
+
+
+    @Extension
+    public static final class DescriptorImpl extends Descriptor<CustomLoggerItem> {
+        @Override
+        public String getDisplayName() {
+            return "CustomLoggerItem";
+        }
+
+        public FormValidation doCheckName(@QueryParameter String value) {
+            if (value == null || value.isEmpty()) {
+                return FormValidation.error("Name cannot be empty");
+            } else {
+                return FormValidation.ok();
+            }
+        }
+
+        public static ListBoxModel doFillCustomLoggerNameItems() {
+            ListBoxModel items = new ListBoxModel();
+
+            for (Map.Entry<String, LogRecorder> e : logRecorderManager.logRecorders.entrySet()) {
+                items.add(e.getKey(), e.getValue().getDisplayName());
+            }
+            return items;
+        }
+    }
+}

--- a/splunk-devops/src/main/java/com/splunk/splunkjenkins/CustomLoggersConfig.java
+++ b/splunk-devops/src/main/java/com/splunk/splunkjenkins/CustomLoggersConfig.java
@@ -1,0 +1,66 @@
+package com.splunk.splunkjenkins;
+
+import hudson.Extension;
+import jenkins.model.GlobalConfiguration;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.StaplerRequest;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Extension
+public class CustomLoggersConfig extends GlobalConfiguration {
+    private static final java.util.logging.Logger LOG = java.util.logging.Logger.getLogger(CustomLoggersConfig.class.getName());
+
+    List<CustomLoggerItem> customLoggers;
+
+    public static CustomLoggersConfig get() {
+        return (CustomLoggersConfig) Jenkins.getInstance().getDescriptor(CustomLoggersConfig.class);
+    }
+
+    public CustomLoggersConfig() {
+        super.load();
+        if (customLoggers == null) {
+            this.customLoggers = new ArrayList<>();
+        }
+    }
+
+    @DataBoundConstructor
+    public CustomLoggersConfig(List<CustomLoggerItem> customLoggers) {
+        if (customLoggers == null) {
+            this.customLoggers = Collections.emptyList();
+        } else {
+            this.customLoggers = customLoggers;
+        }
+        this.save();
+    }
+
+    public List<CustomLoggerItem> getCustomLoggers() {
+        return customLoggers;
+    }
+
+    @DataBoundSetter
+    public void setCustomLoggers(List<CustomLoggerItem> customLoggers) {
+        this.customLoggers = customLoggers;
+    }
+
+    public void addCustomLogger(CustomLoggerItem customLoggerItem) {
+        this.customLoggers.add(customLoggerItem);
+        this.save();
+    }
+
+    @Override
+    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+        if (!json.has("customLoggers")) {
+            json.put("customLoggers", new JSONArray());
+        }
+        req.bindJSON(this, json);
+        save();
+        return true;
+    }
+}

--- a/splunk-devops/src/main/resources/com/splunk/splunkjenkins/CustomLoggerItem/config.jelly
+++ b/splunk-devops/src/main/resources/com/splunk/splunkjenkins/CustomLoggerItem/config.jelly
@@ -1,0 +1,14 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <table width="100%">
+        <f:entry title="${%CustomLoggerName}" field="customLoggerName">
+            <f:select />
+        </f:entry>
+        <f:entry>
+            <div align="right">
+                <f:repeatableDeleteButton />
+            </div>
+        </f:entry>
+    </table>
+</j:jelly>

--- a/splunk-devops/src/main/resources/com/splunk/splunkjenkins/CustomLoggersConfig/config.jelly
+++ b/splunk-devops/src/main/resources/com/splunk/splunkjenkins/CustomLoggersConfig/config.jelly
@@ -1,0 +1,11 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <f:section title="Splunk Custom Loggers Configuration">
+        <f:entry title="Custom Log Recorders to Send to Splunk">
+            <f:repeatable field="customLoggers" minimum="0" default="">
+                <st:include page="config.jelly" class="${descriptor.clazz}" />
+            </f:repeatable>
+        </f:entry>
+    </f:section>
+</j:jelly>

--- a/splunk-devops/src/test/java/com/splunk/splunkjenkins/CustomLoggersConfigTest.java
+++ b/splunk-devops/src/test/java/com/splunk/splunkjenkins/CustomLoggersConfigTest.java
@@ -1,0 +1,31 @@
+package com.splunk.splunkjenkins;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class CustomLoggersConfigTest {
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Test
+    public void roundTripTest() throws Exception {
+        CustomLoggerItem cli1 = new CustomLoggerItem("logger1");
+        CustomLoggerItem cli2 = new CustomLoggerItem("logger2");
+        List<CustomLoggerItem> loggerItems = Arrays.asList(cli1, cli2);
+
+        CustomLoggersConfig config = CustomLoggersConfig.get();
+
+        config.addCustomLogger(cli1);
+        config.addCustomLogger(cli2);
+
+        r.configRoundtrip();
+
+        assertEquals(loggerItems, config.getCustomLoggers());
+    }
+}

--- a/splunk-devops/src/test/java/com/splunk/splunkjenkins/JdkSplunkLogHandlerTest.java
+++ b/splunk-devops/src/test/java/com/splunk/splunkjenkins/JdkSplunkLogHandlerTest.java
@@ -36,4 +36,8 @@ public class JdkSplunkLogHandlerTest extends BaseTest {
         verifySplunkSearchResult(message + " level=INFO", 1);
     }
 
+    @Test
+    public void publishCustomLogger() throws Exception {
+
+    }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Background: Jenkins system log defaults to ignore all logs below the INFO priority level, meaning certain logs of interest aren't being sent to Splunk. Wanted a way to configure Jenkins so that certain logs are still being sent to Splunk regardless of log priority level (as this level is up to the plugin implementation and not controllable by the end user)

Adds a new section to the Splunk-Devops configuration page that allows Admins to specify any custom loggers to have their logs sent to Splunk regardless of log level.

Configuration page will have a dropdown selection that is populated by the list of configured custom loggers at <JENKINS_URL>/log/

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

![image](https://user-images.githubusercontent.com/11794153/161884646-17232919-6346-4621-93ea-a44ccc29a7c9.png)
![image](https://user-images.githubusercontent.com/11794153/161884681-cb8c3de8-ac65-430b-b3d9-7b1275ee1b92.png)

