### PR TITLE
SECURITY-2401 Fix credentials leakage to Splunk

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.3</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.splunk.splunkins</groupId>
     <artifactId>pom</artifactId>
-    <version>1.9.10-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
     <packaging>pom</packaging>
 
     <name>Splunk Plugin Main Module</name>
@@ -35,10 +35,11 @@
         <connection>scm:git:git://github.com/jenkinsci/splunk-devops-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/splunk-devops-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/splunk-devops-plugin</url>
-        <tag>pom-1.3</tag>
     </scm>
 
     <properties>
+        <revision>1.9.10</revision>
+        <changelist>-SNAPSHOT</changelist>
         <!-- *.html files are in UTF-8, and *.properties are in iso-8859-1, so this configuration is acturally incorrect,
         but this suppresses a warning from Maven, and as long as we don't do filtering we should be OK. -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -53,7 +54,7 @@
         <findbugs-maven-plugin.version>3.0.1</findbugs-maven-plugin.version>
         <java.level>8</java.level>
         <!-- jenkins requirement -->
-        <jenkins.version>2.60.3</jenkins.version>
+        <jenkins.version>2.235.5</jenkins.version>
         <spotbugs.failOnError>false</spotbugs.failOnError>
         <surefire.timeout>600</surefire.timeout>
     </properties>
@@ -106,6 +107,36 @@
                     <artifactId>jsr305</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.26</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>1.7.26</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <version>1.7.26</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>log4j-over-slf4j</artifactId>
+            <version>1.7.26</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-api</artifactId>
+            <version>1137.v36a_8153e5c69</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>structs</artifactId>
+            <version>1.23</version>
         </dependency>
     </dependencies>
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <findbugs-maven-plugin.version>3.0.1</findbugs-maven-plugin.version>
         <java.level>8</java.level>
         <!-- jenkins requirement -->
-        <jenkins.version>2.235.5</jenkins.version>
+        <jenkins.version>2.60.3</jenkins.version>
         <spotbugs.failOnError>false</spotbugs.failOnError>
         <surefire.timeout>600</surefire.timeout>
     </properties>

--- a/splunk-devops-extend/pom.xml
+++ b/splunk-devops-extend/pom.xml
@@ -21,7 +21,7 @@
         </license>
     </licenses>
     <properties>
-        <jenkins.version>2.249.1</jenkins.version>
+        <jenkins.version>2.332.3</jenkins.version>
     </properties>
     <developers>
         <developer>
@@ -131,6 +131,46 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
             <version>2.6.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <version>1.7.33</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.33</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>1.7.33</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>log4j-over-slf4j</artifactId>
+            <version>1.7.33</version>
+        </dependency>
+        <dependency>
+            <groupId>org.kohsuke</groupId>
+            <artifactId>access-modifier-annotation</artifactId>
+            <version>1.27</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci</groupId>
+            <artifactId>annotation-indexer</artifactId>
+            <version>1.16</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci</groupId>
+            <artifactId>annotation-indexer</artifactId>
+            <version>1.16</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <version>4.5.2</version>
         </dependency>
     </dependencies>
 </project>

--- a/splunk-devops-extend/pom.xml
+++ b/splunk-devops-extend/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.splunk.splunkins</groupId>
         <artifactId>pom</artifactId>
-        <version>1.9.10-SNAPSHOT</version>
+        <version>${revision}${changelist}</version>
     </parent>
 
     <artifactId>splunk-devops-extend</artifactId>
@@ -21,7 +21,7 @@
         </license>
     </licenses>
     <properties>
-        <jenkins.version>2.138.4</jenkins.version>
+        <jenkins.version>2.249.1</jenkins.version>
     </properties>
     <developers>
         <developer>
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.36</version>
+            <version>1137.v36a_8153e5c69</version>
             <!--TaskListenerDecorator API is stable since 2.36-->
         </dependency>
         <dependency>
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.17</version>
+            <version>1.23</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -122,6 +122,15 @@
             <version>1.2.1</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-step-api</artifactId>
+            <version>2.24</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>scm-api</artifactId>
+            <version>2.6.5</version>
+        </dependency>
     </dependencies>
 </project>

--- a/splunk-devops-extend/src/main/java/com/splunk/splunkjenkins/console/LabelConsoleLineStream.java
+++ b/splunk-devops-extend/src/main/java/com/splunk/splunkjenkins/console/LabelConsoleLineStream.java
@@ -2,6 +2,7 @@ package com.splunk.splunkjenkins.console;
 
 import com.splunk.splunkjenkins.model.EventRecord;
 import hudson.util.ByteArrayOutputStream2;
+import org.apache.commons.lang.StringUtils;
 
 import java.io.FilterOutputStream;
 import java.io.IOException;
@@ -9,8 +10,6 @@ import java.io.OutputStream;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
-
-import org.apache.commons.lang.StringUtils;
 
 import static com.splunk.splunkjenkins.Constants.CONSOLE_TEXT_SINGLE_LINE_MAX_LENGTH;
 import static com.splunk.splunkjenkins.model.EventType.CONSOLE_LOG;

--- a/splunk-devops-extend/src/main/java/com/splunk/splunkjenkins/console/SplunkTaskListenerFactory.java
+++ b/splunk-devops-extend/src/main/java/com/splunk/splunkjenkins/console/SplunkTaskListenerFactory.java
@@ -21,7 +21,7 @@ import static com.splunk.splunkjenkins.model.EventType.CONSOLE_LOG;
 
 @Extension(optional = true)
 public class SplunkTaskListenerFactory implements TaskListenerDecorator.Factory {
-    private static final Logger LOGGER = Logger.getLogger(SplunkConsoleTaskListenerDecorator.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(SplunkTaskListenerFactory.class.getName());
     private static final boolean ENABLE_REMOTE_DECORATOR = Boolean.parseBoolean(System.getProperty("splunkins.enableRemoteTaskListenerDecorator", "true"));
     private static final transient LoadingCache<WorkflowRun, SplunkConsoleTaskListenerDecorator> cachedDecorator = CacheBuilder.newBuilder()
             .weakKeys()
@@ -61,6 +61,11 @@ public class SplunkTaskListenerFactory implements TaskListenerDecorator.Factory 
             LOGGER.finer("failed to load cached decorator");
         }
         return null;
+    }
+
+    @Override
+    public boolean isAppliedBeforeMainDecorator() {
+        return true;
     }
 
     public static void removeCache(WorkflowRun run) {

--- a/splunk-devops-shaded/pom.xml
+++ b/splunk-devops-shaded/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.splunk.splunkins</groupId>
         <artifactId>pom</artifactId>
-        <version>1.9.10-SNAPSHOT</version>
+        <version>${revision}${changelist}</version>
     </parent>
 
     <artifactId>splunk-devops-shaded</artifactId>
@@ -72,6 +72,11 @@
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.6.2</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.14</version>
         </dependency>
     </dependencies>
 

--- a/splunk-devops/pom.xml
+++ b/splunk-devops/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.splunk.splunkins</groupId>
         <artifactId>pom</artifactId>
-        <version>1.9.10-SNAPSHOT</version>
+        <version>${revision}${changelist}</version>
     </parent>
 
     <artifactId>splunk-devops</artifactId>
@@ -23,6 +23,9 @@
             <url>http://opensource.org/licenses/MIT</url>
         </license>
     </licenses>
+    <properties>
+        <jenkins.version>2.249.1</jenkins.version>
+    </properties>
     <developers>
         <developer>
             <id>djenkins</id>
@@ -221,6 +224,17 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-api</artifactId>
+            <version>1137.v36a_8153e5c69</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>structs</artifactId>
+            <version>1.23</version>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/splunk-devops/pom.xml
+++ b/splunk-devops/pom.xml
@@ -23,9 +23,6 @@
             <url>http://opensource.org/licenses/MIT</url>
         </license>
     </licenses>
-    <properties>
-        <jenkins.version>2.249.1</jenkins.version>
-    </properties>
     <developers>
         <developer>
             <id>djenkins</id>
@@ -225,16 +222,10 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-api</artifactId>
-            <version>1137.v36a_8153e5c69</version>
-        </dependency>
-        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
             <version>1.23</version>
         </dependency>
-
     </dependencies>
 
 </project>


### PR DESCRIPTION
Proof-of-concept for fix for SECURITY-2401 using incremental workflow-api version 1137.v36a_8153e5c69 ([PR-166](https://github.com/jenkinsci/workflow-api-plugin/pull/166)).

Overrides new **TaskListenerDecorator.Factory.isAppliedBeforeMainDecorator()** method to reorder the **SplunkTaskListenerFactory** to get access to the console output last such that any sensitive data (e.g. via the credentials-binding plugin) will be masked by the time the **LabelConsoleLineStream** gets access to the data stream.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
