### PR TITLE
Added Permission to restrict Splunk Link

### DIFF
--- a/splunk-devops/src/main/java/com/splunk/splunkjenkins/links/ReportAction.java
+++ b/splunk-devops/src/main/java/com/splunk/splunkjenkins/links/ReportAction.java
@@ -4,23 +4,49 @@ import com.splunk.splunkjenkins.Messages;
 import com.splunk.splunkjenkins.SplunkJenkinsInstallation;
 import hudson.Extension;
 import hudson.model.RootAction;
+import hudson.security.Permission;
+import hudson.security.PermissionGroup;
+import hudson.security.PermissionScope;
+import jenkins.model.Jenkins;
 
 @SuppressWarnings("unused")
 @Extension
 public class ReportAction implements RootAction {
+
+    /**
+     * Permission group for Splunk Link related permissions.
+     */
+    public static final PermissionGroup PERMISSIONS =
+            new PermissionGroup(ReportAction.class, Messages._PermissionGroup());
+    /**
+     * Permission to get the Splunk link displayed.
+     */
+    public static final Permission SPLUNK_LINK = new Permission(PERMISSIONS,
+            "SplunkLink", Messages._PluginViewPermission_Description(), Jenkins.ADMINISTER, PermissionScope.JENKINS);
+
+
     @Override
     public String getIconFileName() {
-        return Messages.SplunkIconName();
+        if (Jenkins.getInstance().hasPermission(ReportAction.SPLUNK_LINK)){
+            return Messages.SplunkIconName();
+        }
+        return null;
     }
 
     @Override
     public String getDisplayName() {
-        return "Splunk";
+        if (Jenkins.getInstance().hasPermission(ReportAction.SPLUNK_LINK)){
+            return "Splunk";
+        }
+        return null;
     }
 
     @Override
     public String getUrlName() {
-        SplunkJenkinsInstallation instance = SplunkJenkinsInstallation.get();
-        return instance.getAppUrlOrHelp() + "overview?overview_jenkinsmaster=" + instance.getMetadataHost();
+        if (Jenkins.getInstance().hasPermission(ReportAction.SPLUNK_LINK)){
+            SplunkJenkinsInstallation instance = SplunkJenkinsInstallation.get();
+            return instance.getAppUrlOrHelp() + "overview?overview_jenkinsmaster=" + instance.getMetadataHost();
+        }
+        return null;
     }
 }

--- a/splunk-devops/src/main/resources/com/splunk/splunkjenkins/Messages.properties
+++ b/splunk-devops/src/main/resources/com/splunk/splunkjenkins/Messages.properties
@@ -38,3 +38,5 @@ InvalidPattern=The pattern is invalid, please check <a href="https://docs.oracle
 InvalidHostOrToken=Invalid config, please check Hostname or Token
 SplunArtifactArchive=Send files to Splunk
 SplunkIconName=/plugin/splunk-devops/images/splunk_logo_green.png
+PermissionGroup=Splunk
+PluginViewPermission.Description=This permission grants access to the Splunk Instance Link.


### PR DESCRIPTION
Added Permission to restrict Splunk Link. In our case only the admins should see the Link because the users in general will not get the rights within Splunk to see anything. Since our use case might be a little special I decided to make the rights configurable. The matrix-based authorization looks now like this (with the new Splunk permission group):
![grafik](https://user-images.githubusercontent.com/22742658/170865802-4613edc0-7b81-4bd2-9eb5-408e2e6e552c.png)
