### PR TITLE
[JENKINS-68440] fix: null pointer exception in LabelMarkupText

### DIFF
--- a/splunk-devops-extend/src/main/java/com/splunk/splunkjenkins/console/ConsoleNoteHandler.java
+++ b/splunk-devops-extend/src/main/java/com/splunk/splunkjenkins/console/ConsoleNoteHandler.java
@@ -1,5 +1,6 @@
 package com.splunk.splunkjenkins.console;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.xml.sax.SAXException;
 
 import javax.xml.stream.XMLEventReader;
@@ -53,6 +54,7 @@ public class ConsoleNoteHandler {
      * @see hudson.console.HyperlinkNote
      * @see org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApprovalNote
      */
+    @SuppressFBWarnings("SF_SWITCH_NO_DEFAULT")
     public void read(String xml) throws XMLStreamException {
         XMLEventReader reader = xmlInputFactory.createXMLEventReader(new StringReader(xml));
         while (reader.hasNext()) {

--- a/splunk-devops-extend/src/main/java/com/splunk/splunkjenkins/console/LabelMarkupText.java
+++ b/splunk-devops-extend/src/main/java/com/splunk/splunkjenkins/console/LabelMarkupText.java
@@ -15,6 +15,7 @@ import java.util.logging.Logger;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import static org.apache.commons.lang.StringUtils.isNotEmpty;
+import static org.apache.commons.lang.StringUtils.startsWith;
 
 public class LabelMarkupText extends MarkupText {
     private static final Boolean isDisabled = Boolean.getBoolean(LogEventHelper.class.getName() + ".disableLabelMarkup");
@@ -69,7 +70,7 @@ public class LabelMarkupText extends MarkupText {
                     // BlockEndNode or BlockStartNode
                     encloseLabel = null;
                     String label = handler.getLabel();
-                    if (label.startsWith(PARALLEL_BRANCH_LABEL)) {
+                    if (startsWith(label, PARALLEL_BRANCH_LABEL)) {
                         encloseLabels.put(nodeId, label.substring(PARALLEL_BRANCH_LABEL.length()));
                     }
                 } else {

--- a/splunk-devops/src/main/java/com/splunk/splunkjenkins/listeners/LoggingQueueListener.java
+++ b/splunk-devops/src/main/java/com/splunk/splunkjenkins/listeners/LoggingQueueListener.java
@@ -38,7 +38,7 @@ public class LoggingQueueListener extends QueueListener {
     private final static ConcurrentHashMap<Long, Long> queuePhase = new ConcurrentHashMap<Long, Long>();
     // default is 3 question masks ???, see also hudson/model/Messages
     // due to access policy hudson/model/Messages must not be used, hard code it here
-    private final String QUEUE_UNKNOWN_MSG = "???";
+    private final static String QUEUE_UNKNOWN_MSG = "???";
 
     @Override
     public void onEnterWaiting(Queue.WaitingItem wi) {


### PR DESCRIPTION
If the tag contains a startId but no label a npe is thrown.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Use null safe startsWith for label attribute.
