### PR TITLE
Default to verifying splunk cert

### DIFF
--- a/splunk-devops/src/main/java/com/splunk/splunkjenkins/utils/SplunkLogService.java
+++ b/splunk-devops/src/main/java/com/splunk/splunkjenkins/utils/SplunkLogService.java
@@ -4,6 +4,7 @@ import com.google.common.base.Strings;
 import com.splunk.splunkjenkins.SplunkJenkinsInstallation;
 import com.splunk.splunkjenkins.model.EventRecord;
 import com.splunk.splunkjenkins.model.EventType;
+import jenkins.util.SystemProperties;
 import shaded.splk.org.apache.http.HttpResponse;
 import shaded.splk.org.apache.http.client.HttpClient;
 import shaded.splk.org.apache.http.client.config.CookieSpecs;
@@ -42,7 +43,7 @@ import static com.splunk.splunkjenkins.model.EventType.BATCH_JSON;
 
 public class SplunkLogService {
     public static final java.util.logging.Logger LOG = java.util.logging.Logger.getLogger(SplunkLogService.class.getName());
-    private static final boolean VERIFY_SSL = Boolean.getBoolean("splunkins.verifySSL");
+    private static final boolean VERIFY_SSL = SystemProperties.getBoolean("splunkins.verifySSL");
     private final static int SOCKET_TIMEOUT = 3;
     private final static int QUEUE_SIZE = Integer.getInteger(SplunkLogService.class.getName() + ".queueSize", 1 << 17);
     private final static long KEEP_ALIVE_TIME_MINUTES = 2;


### PR DESCRIPTION
The SSL cert verification is not performed by default, and needs to be turned on by system property - which is obscuring the need to do so at all.

This change flips the default without changing any functionality. When the flag is not provided, it verifies the cert unless `-Dsplunkins.verifySSL=false` is provided.

This was verified manually to actually trust self-signed certs before, while it rejects them afterwards.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [n/a] Link to relevant issues in GitHub or Jira
- [n/a] Link to relevant pull requests, esp. upstream and downstream changes
- [n/a] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
