### PR TITLE
Handle maven notes

### DIFF
--- a/splunk-devops-extend/src/main/java/com/splunk/splunkjenkins/console/ConsoleNoteHandler.java
+++ b/splunk-devops-extend/src/main/java/com/splunk/splunkjenkins/console/ConsoleNoteHandler.java
@@ -1,6 +1,7 @@
 package com.splunk.splunkjenkins.console;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.apache.commons.lang.StringUtils;
 import org.xml.sax.SAXException;
 
 import javax.xml.stream.XMLEventReader;
@@ -56,6 +57,13 @@ public class ConsoleNoteHandler {
      */
     @SuppressFBWarnings("SF_SWITCH_NO_DEFAULT")
     public void read(String xml) throws XMLStreamException {
+        // fix Maven notes which add invalid markup
+        // https://github.com/jenkinsci/jenkins/blob/c3ebd9dc706897c281036671eed6851390f85ade/core/src/main/java/hudson/tasks/_maven/MavenMojoNote.java#L50
+        xml = StringUtils.replace(xml, "<b class=maven-mojo>", "<b class=\"maven-mojo\">");
+        // https://github.com/jenkinsci/jenkins/blob/c3ebd9dc706897c281036671eed6851390f85ade/core/src/main/java/hudson/tasks/_maven/MavenWarningNote.java#L47
+        xml = StringUtils.replace(xml, "<span class=warning-inline>", "<span class=\"warning-inline\">");
+        // https://github.com/jenkinsci/jenkins/blob/c3ebd9dc706897c281036671eed6851390f85ade/core/src/main/java/hudson/tasks/_maven/MavenErrorNote.java#L45
+        xml = StringUtils.replace(xml, "<span class=error-inline>", "<span class=\"error-inline\">");
         XMLEventReader reader = xmlInputFactory.createXMLEventReader(new StringReader(xml));
         while (reader.hasNext()) {
             XMLEvent nextEvent = reader.nextEvent();

--- a/splunk-devops-extend/src/test/java/com/splunk/splunkjenkins/console/ConsoleNoteHandlerTest.java
+++ b/splunk-devops-extend/src/test/java/com/splunk/splunkjenkins/console/ConsoleNoteHandlerTest.java
@@ -1,0 +1,43 @@
+package com.splunk.splunkjenkins.console;
+
+import static junit.framework.Assert.assertNull;
+import static junit.framework.TestCase.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import hudson.tasks._maven.Maven3MojoNote;
+import org.junit.Test;
+
+public class ConsoleNoteHandlerTest {
+    @Test
+    public void testReadMavenNote() throws Exception {
+        ConsoleNoteHandler handler = new ConsoleNoteHandler();
+        handler.read("<b class=maven-mojo></b>");
+        assertNull(handler.getHref());
+        assertNull(handler.getNodeId());
+        assertNull(handler.getEnclosingId());
+        assertNull(handler.getStartId());
+    }
+
+    @Test
+    public void testReadMavenWarningNote() throws Exception {
+        ConsoleNoteHandler handler = new ConsoleNoteHandler();
+        handler.read("<span class=warning-inline></span>");
+        assertNull(handler.getHref());
+        assertNull(handler.getNodeId());
+        assertNull(handler.getEnclosingId());
+        assertNull(handler.getStartId());
+    }
+
+    @Test
+    public void testReadMavenErrorNote() throws Exception {
+        ConsoleNoteHandler handler = new ConsoleNoteHandler();
+        handler.read("<span class=error-inline></span>");
+        assertNull(handler.getHref());
+        assertNull(handler.getNodeId());
+        assertNull(handler.getEnclosingId());
+        assertNull(handler.getStartId());
+    }
+}


### PR DESCRIPTION
Add special case for Maven notes which don't generate valid xml. The plugin generates lots of warning log messages attempting to parse the invalid xml markup.

Logs are filled with the following error messages without this fix:

```
{"thread_id":123534,"level":"WARNING","log_source":"com.splunk.splunkjenkins.console.LabelMarkupText parseTagLabel","message":"failed to parse html console note <span class=warning-inline></span> exception:javax.xml.stream.XMLStreamException: ParseError at [row,col]:[1,13]\nMessage: Open quote is expected for attribute \"class\" associated with an  element type  \"span\"."}

{"thread_id":185742,"level":"WARNING","log_source":"com.splunk.splunkjenkins.console.LabelMarkupText parseTagLabel","message":"failed to parse html console note <span class=error-inline></span> exception:javax.xml.stream.XMLStreamException: ParseError at [row,col]:[1,13]\nMessage: Open quote is expected for attribute \"class\" associated with an  element type  \"span\"."}

{"thread_id":831113,"level":"WARNING","log_source":"com.splunk.splunkjenkins.console.LabelMarkupText parseTagLabel","message":"failed to parse html console note <b class=maven-mojo></b> exception:javax.xml.stream.XMLStreamException: ParseError at [row,col]:[1,10]\nMessage: Open quote is expected for attribute \"class\" associated with an  element type  \"b\"."}
```

### Testing done

Add unit test for parsing Maven note markup.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
