### PR TITLE
Fix race condition in LabelMarkupText

### DIFF
--- a/splunk-devops-extend/src/main/java/com/splunk/splunkjenkins/console/LabelMarkupText.java
+++ b/splunk-devops-extend/src/main/java/com/splunk/splunkjenkins/console/LabelMarkupText.java
@@ -94,8 +94,9 @@ public class LabelMarkupText extends MarkupText {
     }
 
     public void write(OutputStream out) throws IOException {
-        if (isNotEmpty(annotation)) {
-            out.write(annotation.getBytes(UTF_8));
+        String ann = annotation;
+        if (isNotEmpty(ann)) {
+            out.write(ann.getBytes(UTF_8));
             out.write(' ');
             //clear annotation
             annotation = null;
@@ -103,8 +104,9 @@ public class LabelMarkupText extends MarkupText {
     }
 
     public void writePreviousLabel(OutputStream out) throws IOException {
-        if (isNotEmpty(encloseLabel)) {
-            out.write(encloseLabel.getBytes(UTF_8));
+        String label = encloseLabel;
+        if (isNotEmpty(label)) {
+            out.write(label.getBytes(UTF_8));
             out.write(' ');
         }
     }


### PR DESCRIPTION
In a parallel pipeline script multiple logger write operations can occur against the same TaskListener logger. LabelMarkupText nulls out the annotation field after write which could cause a NPE in a multi threaded pipeline because the same LabelMarkupText instance is used for all write operations.

This change doesn't address the larger thread safety issue with PipelineConsoleDecoder and LabelMarkupText but should prevent a possible NPE in case the the class fields are nulled out between the isEmpty check and the value reference during write.

```
java.lang.NullPointerException
	at com.splunk.splunkjenkins.console.LabelMarkupText.write(LabelMarkupText.java:98)
	at com.splunk.splunkjenkins.console.PipelineConsoleDecoder.decodeConsoleObjectStream(PipelineConsoleDecoder.java:63)
	at com.splunk.splunkjenkins.console.PipelineConsoleDecoder.decodeLine(PipelineConsoleDecoder.java:38)
	at com.splunk.splunkjenkins.console.LabelConsoleLineStream.eol(LabelConsoleLineStream.java:47)
	at com.splunk.splunkjenkins.console.LabelConsoleLineStream.write(LabelConsoleLineStream.java:36)
	at java.base/java.io.FilterOutputStream.write(Unknown Source)
	at org.jenkinsci.plugins.credentialsbinding.masking.SecretPatterns$MaskingOutputStream.eol(SecretPatterns.java:104)
	at hudson.console.LineTransformationOutputStream.eol(LineTransformationOutputStream.java:61)
	at hudson.console.LineTransformationOutputStream.write(LineTransformationOutputStream.java:57)
	at hudson.console.LineTransformationOutputStream.write(LineTransformationOutputStream.java:75)
	at java.base/java.io.PrintStream.write(Unknown Source)
	at java.base/sun.nio.cs.StreamEncoder.writeBytes(Unknown Source)
	at java.base/sun.nio.cs.StreamEncoder.implFlushBuffer(Unknown Source)
	at java.base/sun.nio.cs.StreamEncoder.flushBuffer(Unknown Source)
	at java.base/java.io.OutputStreamWriter.flushBuffer(Unknown Source)
	at java.base/java.io.PrintStream.newLine(Unknown Source)
	at java.base/java.io.PrintStream.println(Unknown Source)
```

<!-- Please describe your pull request here. -->

### Testing done

Testing in local jenkins deployment with parallel step running 22 stages.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
