### PR TITLE
Override `RunActionFactory.actionType`

### DIFF
--- a/splunk-devops/src/main/java/com/splunk/splunkjenkins/links/RunActionFactory.java
+++ b/splunk-devops/src/main/java/com/splunk/splunkjenkins/links/RunActionFactory.java
@@ -21,6 +21,11 @@ public class RunActionFactory extends TransientActionFactory<Run> {
         return Run.class;
     }
 
+    @Override
+    public Class<? extends Action> actionType() {
+        return LinkSplunkAction.class;
+    }
+
     @NonNull
     @Override
     public Collection<? extends Action> createFor(@NonNull Run target) {


### PR DESCRIPTION
I saw a thread dump from a controller running this plugin that included numerous threads blocked in file I/O in `RunActionFactory.createFor` where the caller did not need to be running this code at all, for example:

```
   java.lang.Thread.State: RUNNABLE
	at java.io.UnixFileSystem.getBooleanAttributes0(java.base@21.0.8/Native Method)
	at java.io.UnixFileSystem.hasBooleanAttributes(java.base@21.0.8/UnixFileSystem.java:194)
	at java.io.File.exists(java.base@21.0.8/File.java:836)
	at com.splunk.splunkjenkins.links.RunActionFactory.createFor(RunActionFactory.java:32)
	at com.splunk.splunkjenkins.links.RunActionFactory.createFor(RunActionFactory.java:16)
	at hudson.model.Actionable.createFor(Actionable.java:118)
	at hudson.model.Actionable.getAction(Actionable.java:335)
	at hudson.plugins.gradle.injection.BuildScanEnvironmentContributor.alreadyExecuted(BuildScanEnvironmentContributor.java:122)
	at hudson.plugins.gradle.injection.BuildScanEnvironmentContributor.buildEnvironmentFor(BuildScanEnvironmentContributor.java:46)
	at hudson.model.Run.getEnvironment(Run.java:2431)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.getEnvironment(WorkflowRun.java:525)
	at org.jenkinsci.plugins.workflow.cps.EnvActionImpl.getEnvironment(EnvActionImpl.java:92)
	at org.jenkinsci.plugins.workflow.cps.EnvActionImpl.getProperty(EnvActionImpl.java:108)
	at org.jenkinsci.plugins.workflow.cps.EnvActionImpl.getProperty(EnvActionImpl.java:59)
	at …
```

```
   java.lang.Thread.State: RUNNABLE
	at java.io.UnixFileSystem.getBooleanAttributes0(java.base@21.0.8/Native Method)
	at java.io.UnixFileSystem.hasBooleanAttributes(java.base@21.0.8/UnixFileSystem.java:194)
	at java.io.File.exists(java.base@21.0.8/File.java:836)
	at com.splunk.splunkjenkins.links.RunActionFactory.createFor(RunActionFactory.java:32)
	at com.splunk.splunkjenkins.links.RunActionFactory.createFor(RunActionFactory.java:16)
	at hudson.model.Actionable.createFor(Actionable.java:118)
	at hudson.model.Actionable.getAction(Actionable.java:335)
	at com.cloudbees.plugins.credentials.builds.CredentialsParameterBinder.getOrCreate(CredentialsParameterBinder.java:58)
	at com.cloudbees.plugins.credentials.CredentialsProvider.findCredentialById(CredentialsProvider.java:913)
	at com.cloudbees.plugins.credentials.CredentialsProvider.findCredentialById(CredentialsProvider.java:864)
	at org.jenkinsci.plugins.pipeline.modeldefinition.model.CredentialsBindingHandler.forId(CredentialsBindingHandler.java:95)
	at org.jenkinsci.plugins.pipeline.modeldefinition.model.CredentialsBindingHandler$forId$2.call(Unknown Source)
	at …
```

Implementing `actionType` will not address all cases but it should help.
