### PR TITLE
Add createSubmit to audit trail filter pattern

### DIFF
--- a/splunk-devops/src/main/java/com/splunk/splunkjenkins/WebPostAccessLogger.java
+++ b/splunk-devops/src/main/java/com/splunk/splunkjenkins/WebPostAccessLogger.java
@@ -22,7 +22,8 @@ import static com.splunk.splunkjenkins.model.EventType.JENKINS_CONFIG;
 
 public class WebPostAccessLogger implements Filter {
     private static final Logger LOG = Logger.getLogger(WebPostAccessLogger.class.getName());
-    private static final Pattern FILTER_PATTERN = Pattern.compile("/(?:configSubmit|updateSubmit|script|doDelete)");
+    // Package-visible for testing
+    static final Pattern FILTER_PATTERN = Pattern.compile("/(?:configSubmit|createSubmit|updateSubmit|script|doDelete)");
 
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {

--- a/splunk-devops/src/test/java/com/splunk/splunkjenkins/WebPostAccessLoggerTest.java
+++ b/splunk-devops/src/test/java/com/splunk/splunkjenkins/WebPostAccessLoggerTest.java
@@ -1,0 +1,112 @@
+package com.splunk.splunkjenkins;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link WebPostAccessLogger} pattern matching.
+ * These tests verify that the audit trail filter correctly identifies
+ * URLs that should be logged for security auditing purposes.
+ */
+public class WebPostAccessLoggerTest {
+
+    // ==================== configSubmit tests ====================
+
+    @Test
+    public void testConfigSubmitMatches() {
+        assertTrue("configSubmit should match", WebPostAccessLogger.FILTER_PATTERN.matcher("/job/test/configSubmit").find());
+        assertTrue("configSubmit should match", WebPostAccessLogger.FILTER_PATTERN.matcher("/manage/configSubmit").find());
+    }
+
+    // ==================== createSubmit tests ====================
+
+    @Test
+    public void testCreateSubmitMatchesCredentials() {
+        // Credential creation - the main use case this fix addresses
+        assertTrue("createSubmit for credentials should match",
+                WebPostAccessLogger.FILTER_PATTERN.matcher("/manage/credentials/store/system/domain/_/createSubmit").find());
+        assertTrue("createSubmit for folder credentials should match",
+                WebPostAccessLogger.FILTER_PATTERN.matcher("/job/folder/credentials/store/folder/domain/_/createSubmit").find());
+    }
+
+    @Test
+    public void testCreateSubmitMatchesOtherResources() {
+        // View creation
+        assertTrue("createSubmit for views should match",
+                WebPostAccessLogger.FILTER_PATTERN.matcher("/view/All/createSubmit").find());
+        // Generic createSubmit
+        assertTrue("generic createSubmit should match",
+                WebPostAccessLogger.FILTER_PATTERN.matcher("/createSubmit").find());
+    }
+
+    // ==================== updateSubmit tests ====================
+
+    @Test
+    public void testUpdateSubmitMatches() {
+        assertTrue("updateSubmit for credentials should match",
+                WebPostAccessLogger.FILTER_PATTERN.matcher("/manage/credentials/store/system/domain/_/credential/my-cred/updateSubmit").find());
+        assertTrue("updateSubmit for job should match",
+                WebPostAccessLogger.FILTER_PATTERN.matcher("/job/test/updateSubmit").find());
+    }
+
+    // ==================== script tests ====================
+
+    @Test
+    public void testScriptMatches() {
+        // Script console - security sensitive
+        assertTrue("script console should match",
+                WebPostAccessLogger.FILTER_PATTERN.matcher("/script").find());
+        assertTrue("scriptText should match",
+                WebPostAccessLogger.FILTER_PATTERN.matcher("/manage/scriptText").find());
+        assertTrue("folder scriptText should match",
+                WebPostAccessLogger.FILTER_PATTERN.matcher("/job/folder/scriptText").find());
+    }
+
+    // ==================== doDelete tests ====================
+
+    @Test
+    public void testDoDeleteMatches() {
+        assertTrue("doDelete for credentials should match",
+                WebPostAccessLogger.FILTER_PATTERN.matcher("/manage/credentials/store/system/domain/_/credential/my-cred/doDelete").find());
+        assertTrue("doDelete for job should match",
+                WebPostAccessLogger.FILTER_PATTERN.matcher("/job/test/doDelete").find());
+    }
+
+    // ==================== Negative tests - should NOT match ====================
+
+    @Test
+    public void testRegularRequestsDoNotMatch() {
+        // Regular API calls should not trigger audit
+        assertFalse("API json should not match",
+                WebPostAccessLogger.FILTER_PATTERN.matcher("/api/json").find());
+        assertFalse("Job build should not match",
+                WebPostAccessLogger.FILTER_PATTERN.matcher("/job/test/build").find());
+        assertFalse("Job console should not match",
+                WebPostAccessLogger.FILTER_PATTERN.matcher("/job/test/1/console").find());
+        assertFalse("Credentials list should not match",
+                WebPostAccessLogger.FILTER_PATTERN.matcher("/credentials/store/system/domain/_/").find());
+    }
+
+    @Test
+    public void testPatternMatchesSuffixVariations() {
+        // The pattern uses .find() which matches if /keyword appears as substring
+        // This means suffixes after the keyword will still match
+        assertTrue("configSubmittal contains /configSubmit - should match",
+                WebPostAccessLogger.FILTER_PATTERN.matcher("/configSubmittal").find());
+        assertTrue("doDeleteAll contains /doDelete - should match",
+                WebPostAccessLogger.FILTER_PATTERN.matcher("/doDeleteAll").find());
+        assertTrue("createSubmitForm contains /createSubmit - should match",
+                WebPostAccessLogger.FILTER_PATTERN.matcher("/createSubmitForm").find());
+    }
+
+    @Test
+    public void testPatternDoesNotMatchPrefixVariations() {
+        // Prefix before the keyword breaks the /keyword pattern
+        assertFalse("myCreateSubmit - no /createSubmit pattern",
+                WebPostAccessLogger.FILTER_PATTERN.matcher("/myCreateSubmit").find());
+        assertFalse("preConfigSubmit - no /configSubmit pattern",
+                WebPostAccessLogger.FILTER_PATTERN.matcher("/preConfigSubmit").find());
+    }
+}


### PR DESCRIPTION
## Summary

The `WebPostAccessLogger` filter pattern was missing `createSubmit`, which meant that credential creation events (and other resource creation via `createSubmit` endpoints) were not being logged to the audit trail in Splunk.

## Problem

When auditing Jenkins activity via Splunk, credential **updates** and **deletions** were properly logged, but credential **creations** were silently ignored:

| Action | Before | After |
|--------|--------|-------|
| `configSubmit` | ✅ logged | ✅ logged |
| `updateSubmit` | ✅ logged | ✅ logged |
| `doDelete` | ✅ logged | ✅ logged |
| `createSubmit` | ❌ **NOT logged** | ✅ logged |

This is a security gap - there was no way to audit who created a credential from the audit trail.

## Fix

Added `createSubmit` to the `FILTER_PATTERN` regex in `WebPostAccessLogger.java`.

## Testing

- Added comprehensive unit tests for the filter pattern (`WebPostAccessLoggerTest.java`)
- Changed pattern visibility from `private` to package-visible to allow tests to reference the actual pattern (avoiding duplication)
- All 9 tests pass

## Verification

This issue was discovered and verified on a production Jenkins controller by:
1. Creating a test credential → No audit event logged (only `updated credentials.xml` by SYSTEM)
2. Updating the credential → Audit event properly logged with user attribution
3. Deleting the credential → Audit event properly logged with user attribution