### PR TITLE
Check if it should enable remote decorator for all SplunkConsoleTaskListenerDecorator objects

### DIFF
--- a/splunk-devops-extend/src/main/java/com/splunk/splunkjenkins/console/SplunkConsoleTaskListenerDecorator.java
+++ b/splunk-devops-extend/src/main/java/com/splunk/splunkjenkins/console/SplunkConsoleTaskListenerDecorator.java
@@ -1,5 +1,6 @@
 package com.splunk.splunkjenkins.console;
 
+import com.splunk.splunkjenkins.SplunkJenkinsInstallation;
 import com.splunk.splunkjenkins.utils.RemoteUtils;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jenkins.util.JenkinsJVM;
@@ -13,6 +14,7 @@ import java.util.Map;
 
 public class SplunkConsoleTaskListenerDecorator extends TaskListenerDecorator {
     private static final long serialVersionUID = 1L;
+    private static final boolean ENABLE_REMOTE_DECORATOR = Boolean.parseBoolean(System.getProperty("splunkins.enableRemoteTaskListenerDecorator", "true"));
     @SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
     transient PipelineConsoleDecoder decoder;
     // it is optional but not use Optional<Map> since Optional is not serializable
@@ -22,6 +24,9 @@ public class SplunkConsoleTaskListenerDecorator extends TaskListenerDecorator {
     public SplunkConsoleTaskListenerDecorator(WorkflowRun run) {
         this.decoder = new PipelineConsoleDecoder(run);
         this.source = run.getUrl() + "console";
+        if (ENABLE_REMOTE_DECORATOR) {
+            setRemoteSplunkinsConfig(SplunkJenkinsInstallation.get().toMap());
+        }
     }
 
     @NonNull
@@ -43,7 +48,7 @@ public class SplunkConsoleTaskListenerDecorator extends TaskListenerDecorator {
         return new LabelConsoleLineStream(outputStream, source, decoder);
     }
 
-    protected void setRemoteSplunkinsConfig(Map remoteSplunkinsConfig) {
+    private void setRemoteSplunkinsConfig(Map remoteSplunkinsConfig) {
         this.remoteSplunkinsConfig = remoteSplunkinsConfig;
     }
 }

--- a/splunk-devops-extend/src/main/java/com/splunk/splunkjenkins/console/SplunkTaskListenerFactory.java
+++ b/splunk-devops-extend/src/main/java/com/splunk/splunkjenkins/console/SplunkTaskListenerFactory.java
@@ -23,18 +23,13 @@ import static com.splunk.splunkjenkins.model.EventType.CONSOLE_LOG;
 @Extension(optional = true)
 public class SplunkTaskListenerFactory implements TaskListenerDecorator.Factory {
     private static final Logger LOGGER = Logger.getLogger(SplunkConsoleTaskListenerDecorator.class.getName());
-    private static final boolean ENABLE_REMOTE_DECORATOR = Boolean.parseBoolean(System.getProperty("splunkins.enableRemoteTaskListenerDecorator", "true"));
     private static final transient LoadingCache<WorkflowRun, SplunkConsoleTaskListenerDecorator> cachedDecorator = CacheBuilder.newBuilder()
             .weakKeys()
             .maximumSize(1024)
             .build(new CacheLoader<WorkflowRun, SplunkConsoleTaskListenerDecorator>() {
                 @Override
                 public SplunkConsoleTaskListenerDecorator load(WorkflowRun key) {
-                    SplunkConsoleTaskListenerDecorator decorator = new SplunkConsoleTaskListenerDecorator(key);
-                    if (ENABLE_REMOTE_DECORATOR) {
-                        decorator.setRemoteSplunkinsConfig(SplunkJenkinsInstallation.get().toMap());
-                    }
-                    return decorator;
+                    return new SplunkConsoleTaskListenerDecorator(key);
                 }
             });
 


### PR DESCRIPTION
At https://issues.jenkins.io/browse/JENKINS-76340 I reported an issue with the reproduction steps, this is a proposal to fix it. It can be implemented in another way, as long as the SplunkConsoleTaskListenerDecorator initiated by SplunkConsoleLogStep has the remoteSplunkinsConfig.


### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
